### PR TITLE
Bump Nix dependencies

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": null,
         "owner": "commercialhaskell",
         "repo": "all-cabal-hashes",
-        "rev": "14c3f5996b58d08ea9730085efbc81d45810b17b",
-        "sha256": "0sq376yfhwjq0dhg8g4nmkvdhnwycy2y61va0j81fg7lfdygmjlv",
+        "rev": "55f0640818e41a97c3090e6c671f6f50654ca11d",
+        "sha256": "04hjlblmyqkzhz073mvbyg9chr5jrvxzk2whk4hh6mw1pjs8l10z",
         "type": "file",
-        "url": "https://github.com/commercialhaskell/all-cabal-hashes/archive/14c3f5996b58d08ea9730085efbc81d45810b17b.tar.gz",
+        "url": "https://github.com/commercialhaskell/all-cabal-hashes/archive/55f0640818e41a97c3090e6c671f6f50654ca11d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "language-rust": {
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "nmattia",
         "repo": "naersk",
-        "rev": "d7bfbad3304fd768c0f93a4c3b50976275e6d4be",
-        "sha256": "1pvp7v648fm434mvii9ckpg154pchk2jnn049aw96qdq5zkna0fz",
+        "rev": "e0fe990b478a66178a58c69cf53daec0478ca6f9",
+        "sha256": "0qjyfmw5v7s6ynjns4a61vlyj9cghj7vbpgrp9147ngb1f8krz2c",
         "type": "tarball",
-        "url": "https://github.com/nmattia/naersk/archive/d7bfbad3304fd768c0f93a4c3b50976275e6d4be.tar.gz",
+        "url": "https://github.com/nmattia/naersk/archive/e0fe990b478a66178a58c69cf53daec0478ca6f9.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {
@@ -41,10 +41,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "3cd7914b2c4cff48927e11c216dadfab7d903fe5",
-        "sha256": "1agq4nvbhrylf2s77kb4xhh9k7xcwdwggq764k4jgsbs70py8cw3",
+        "rev": "af958e8057f345ee1aca714c1247ef3ba1c15f5e",
+        "sha256": "1qjavxabbrsh73yck5dcq8jggvh3r2jkbr6b5nlz5d9yrqm9255n",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/3cd7914b2c4cff48927e11c216dadfab7d903fe5.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/af958e8057f345ee1aca714c1247ef3ba1c15f5e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "97a13fb97fcda79f9ab3ee73b5dca65eb891c11a",
-        "sha256": "19h94r5sq2q4b1ijxm6a24d8aiib4ps8yxf87figjzd82mvx4xzm",
+        "rev": "c14bb3039f25d463cd24a47d88b4a86b33561788",
+        "sha256": "1mjq4bb8hg890fh39z9hpdndql3571dh8af5civh8qiif34jwpzs",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/97a13fb97fcda79f9ab3ee73b5dca65eb891c11a.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/c14bb3039f25d463cd24a47d88b4a86b33561788.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-mozilla": {

--- a/theta/apps/Apps/Avro.hs
+++ b/theta/apps/Apps/Avro.hs
@@ -12,7 +12,6 @@ import           Control.Monad.IO.Class  (liftIO)
 
 import qualified Data.Aeson              as Aeson
 import qualified Data.ByteString.Lazy    as LBS
-import           Data.Semigroup          ((<>))
 import           Data.String.Interpolate (__i)
 import qualified Data.Text               as Text
 

--- a/theta/apps/Apps/Hash.hs
+++ b/theta/apps/Apps/Hash.hs
@@ -10,7 +10,6 @@ module Apps.Hash where
 import           Control.Monad           (forM_, when)
 import           Control.Monad.IO.Class  (liftIO)
 
-import           Data.Semigroup          ((<>))
 import           Data.String.Interpolate (i)
 
 import           Options.Applicative

--- a/theta/apps/Apps/Rust.hs
+++ b/theta/apps/Apps/Rust.hs
@@ -6,7 +6,6 @@ module Apps.Rust where
 
 import           Control.Monad.Except
 
-import           Data.Semigroup                 ((<>))
 import           Data.String.Interpolate        (__i)
 import           Data.Text.Prettyprint.Doc.Util (putDocW)
 

--- a/theta/apps/Theta.hs
+++ b/theta/apps/Theta.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE QuasiQuotes    #-}
 module Main where
 
-import           Data.Semigroup          ((<>))
 import           Data.String.Interpolate (__i, i)
 
 import           GHC.Exts                (fromString)

--- a/theta/default.nix
+++ b/theta/default.nix
@@ -1,4 +1,4 @@
-{ compiler-version ? "ghc865"
+{ compiler-version ? "ghc884"
 , sources ? import ../nix/sources.nix
 , pkgs ? import ../nix/nixpkgs.nix { inherit sources;}
 , compiler ? pkgs.haskell.packages."${compiler-version}"

--- a/theta/src/Theta/Error.hs
+++ b/theta/src/Theta/Error.hs
@@ -19,8 +19,6 @@ import           Data.Text              (Text)
 import qualified Data.Text              as Text
 import           Data.Void              (Void)
 
-import           System.IO.Error        (IOError)
-
 import qualified Text.Megaparsec        as Megaparsec
 
 import           Theta.Metadata         (Version)

--- a/theta/src/Theta/Import.hs
+++ b/theta/src/Theta/Import.hs
@@ -30,7 +30,6 @@ import qualified Data.Foldable          as Foldable
 import qualified Data.List              as List
 import           Data.List.NonEmpty     (NonEmpty)
 import qualified Data.Map               as Map
-import           Data.Semigroup         ((<>))
 import           Data.Text              (Text)
 import qualified Data.Text              as Text
 import qualified Data.Text.IO           as Text

--- a/theta/src/Theta/Name.hs
+++ b/theta/src/Theta/Name.hs
@@ -13,7 +13,6 @@ import qualified Data.Char       as Char
 import           Data.Hashable   (Hashable)
 import           Data.Maybe      (fromMaybe)
 import qualified Data.Map        as Map
-import           Data.Monoid     ((<>))
 import           Data.Text       (Text)
 import qualified Data.Text       as Text
 import           Data.Tree       (Tree (..))

--- a/theta/src/Theta/Parser.hs
+++ b/theta/src/Theta/Parser.hs
@@ -11,7 +11,6 @@ import qualified Control.Monad.Reader       as Reader
 import           Control.Monad.Trans        (lift)
 
 import           Data.List.NonEmpty         (NonEmpty (..))
-import           Data.Monoid                ((<>))
 import           Data.Text                  (Text)
 import qualified Data.Text                  as Text
 import           Data.Versions              (semver')

--- a/theta/src/Theta/Target/Avro/Error.hs
+++ b/theta/src/Theta/Target/Avro/Error.hs
@@ -22,7 +22,6 @@ import           Data.Hashable            (Hashable)
 import           Data.HashSet             (HashSet)
 import qualified Data.HashSet             as HashSet
 import           Data.List.NonEmpty       (NonEmpty)
-import           Data.Semigroup           ((<>))
 import           Data.Text                (Text)
 import qualified Data.Text                as Text
 import qualified Data.Text.Encoding       as Text

--- a/theta/src/Theta/Target/Avro/Values.hs
+++ b/theta/src/Theta/Target/Avro/Values.hs
@@ -45,7 +45,6 @@ import qualified Data.HashSet               as HashSet
 import           Data.Int                   (Int32, Int64)
 import           Data.List.NonEmpty         (NonEmpty)
 import qualified Data.List.NonEmpty         as NonEmpty
-import           Data.Semigroup             ((<>))
 import qualified Data.Set                   as Set
 import           Data.Text                  (Text)
 import qualified Data.Text                  as Text

--- a/theta/src/Theta/Target/Haskell.hs
+++ b/theta/src/Theta/Target/Haskell.hs
@@ -68,7 +68,6 @@ import           Data.List                       (foldl')
 import           Data.List.NonEmpty              (NonEmpty)
 import qualified Data.List.NonEmpty              as NonEmpty
 import qualified Data.Map                        as Map
-import           Data.Semigroup                  ((<>))
 import qualified Data.Set                        as Set
 import           Data.Tagged                     (Tagged (..))
 import           Data.Text                       (Text)

--- a/theta/src/Theta/Target/Kotlin.hs
+++ b/theta/src/Theta/Target/Kotlin.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes       #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE TypeApplications  #-}
 {-# LANGUAGE ViewPatterns      #-}
 module Theta.Target.Kotlin
   ( Kotlin (..)

--- a/theta/src/Theta/Target/LanguageQuoter.hs
+++ b/theta/src/Theta/Target/LanguageQuoter.hs
@@ -50,7 +50,6 @@
 module Theta.Target.LanguageQuoter where
 
 import           Data.Char                 (isSpace)
-import           Data.Semigroup            ((<>))
 import           Data.Text                 (Text)
 import qualified Data.Text                 as Text
 import           Data.Void                 (Void)

--- a/theta/src/Theta/Target/Python.hs
+++ b/theta/src/Theta/Target/Python.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes       #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE TypeApplications  #-}
 {-# LANGUAGE ViewPatterns      #-}
 
 -- | Compile Theta schemas to Python classes that can

--- a/theta/src/Theta/Types.hs
+++ b/theta/src/Theta/Types.hs
@@ -35,7 +35,6 @@ import           Data.Map                (Map)
 import qualified Data.Map                as Map
 import           Data.Maybe              (catMaybes, listToMaybe)
 import           Data.Ord                (comparing)
-import           Data.Semigroup          ((<>))
 import           Data.Sequence           (Seq ((:<|)), (|>))
 import qualified Data.Sequence           as Seq
 import           Data.Set                (Set)

--- a/theta/test/Test/Theta/Import.hs
+++ b/theta/test/Test/Theta/Import.hs
@@ -20,7 +20,6 @@ module Test.Theta.Import where
 
 import           Control.Monad.Except          (runExceptT)
 
-import           Data.Semigroup                ((<>))
 import           Data.String.Interpolate       (__i)
 import qualified Data.Text                     as Text
 import qualified Data.Text.IO                  as Text

--- a/theta/test/Test/Theta/Target/Avro/Values.hs
+++ b/theta/test/Test/Theta/Target/Avro/Values.hs
@@ -14,7 +14,6 @@ import           Control.Monad.Except            (runExceptT)
 import qualified Data.Avro.Schema                as Schema
 import qualified Data.Avro.Types                 as Avro
 import qualified Data.HashMap.Strict             as HashMap
-import           Data.Semigroup                  ((<>))
 import qualified Data.Text                       as Text
 import qualified Data.Time.Calendar              as Time
 import qualified Data.Time.Clock                 as Time

--- a/theta/test/Test/Theta/Target/Kotlin.hs
+++ b/theta/test/Test/Theta/Target/Kotlin.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE QuasiQuotes           #-}
 {-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TypeApplications      #-}
 module Test.Theta.Target.Kotlin where
 
 import           Theta.Metadata                  (Metadata (..))

--- a/theta/test/Test/Theta/Target/Python.hs
+++ b/theta/test/Test/Theta/Target/Python.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE QuasiQuotes           #-}
 {-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TypeApplications      #-}
 
 -- | Tests for the python code generation from Theta.
 module Test.Theta.Target.Python where

--- a/theta/test/Test/Theta/Target/Python/QuasiQuoter.hs
+++ b/theta/test/Test/Theta/Target/Python/QuasiQuoter.hs
@@ -1,7 +1,8 @@
 -- NOTE: This file *intentionally* doesn't use OverloadedStrings to
 -- ensure the quasiquoter works without the extension enabled (which
 -- was a problem with an initial version of the code)
-{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE QuasiQuotes      #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- | Tests to check that the Python quasiquoter works as
 -- advertised. See the documentation in the

--- a/theta/test/Test/Theta/Target/Rust.hs
+++ b/theta/test/Test/Theta/Target/Rust.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE QuasiQuotes           #-}
 {-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TypeApplications      #-}
 
 module Test.Theta.Target.Rust where
 


### PR DESCRIPTION
Two main changes:

  1. Updated all the Nix sources with Niv.
  2. Switched to GHC 8.8.4 by default.
  
The switch to 8.8.4 exposed a few new errors and warnings which I fixed. Not sure what that does with older GHCs, but I'll cross that bridge later—would be a bit annoyed if I end up needing CPP though.

This change means that the project should mostly build from the public Nix cache now with the exception of the two Haskell dependencies I had to override explicitly (`avro` and `language-rust`).