### PR TITLE
Bump avro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ cabal.sandbox.config
 *.hp
 *.eventlog
 .stack-work/
+stack.yaml.lock
 cabal.project.local
 cabal.project.local~
 .HTF/

--- a/theta/stack.yaml
+++ b/theta/stack.yaml
@@ -1,0 +1,1 @@
+resolver: lts-18.21

--- a/theta/theta.cabal
+++ b/theta/theta.cabal
@@ -32,14 +32,13 @@ common shared
                , aeson
                , aeson-pretty
                , aeson-qq
-               , avro >=0.4.2.0 && <0.4.7
+               , avro >=0.5.2.0
                , binary
                , bytestring
                , containers
                , deepseq
                , filepath
                , hashable
-               , language-rust
                , megaparsec
                , mtl
                , prettyprinter


### PR DESCRIPTION
Bump the lower bound of the **avro** package to the current version on Hackage. The maintainers changed and they made a _lot_ of improvements. As far as I can tell the API didn't change in a way breaks anything for you but I wasn't able to complete a full test build so ymmv, sorry!

Closes #3.