### PR TITLE
Fix Rust code generation + tests

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -32,5 +32,11 @@ let
 in
 # upstream developPackage does not pull in cabal-install
 pkgs.lib.overrideDerivation theta.env (old: {
-    nativeBuildInputs = old.nativeBuildInputs ++ buildInputs;
+  nativeBuildInputs = old.nativeBuildInputs ++ buildInputs;
+
+  # Workaround for Lorri; see:
+  # https://github.com/target/lorri/issues/383
+  shellHook = ''
+    unset SOURCE_DATE_EPOCH
+  '';
 })

--- a/theta/test/Test.hs
+++ b/theta/test/Test.hs
@@ -19,7 +19,7 @@ import qualified Test.Theta.Target.Kotlin             as Kotlin
 import qualified Test.Theta.Target.Python             as Python
 import qualified Test.Theta.Target.Python.QuasiQuoter as Python.QuasiQuoter
 
--- import qualified Test.Theta.Target.Rust               as Rust
+import qualified Test.Theta.Target.Rust               as Rust
 
 tests :: TestTree
 tests = testGroup "Theta"
@@ -43,7 +43,7 @@ tests = testGroup "Theta"
     , Python.tests
     , Python.QuasiQuoter.tests
 
-    -- , Rust.tests
+    , Rust.tests
     ]
   ]
 

--- a/theta/test/Test/Theta/Target/Rust.hs
+++ b/theta/test/Test/Theta/Target/Rust.hs
@@ -8,28 +8,22 @@
 
 module Test.Theta.Target.Rust where
 
-import           Control.Monad                         (zipWithM_)
+import           Control.Monad                 (zipWithM_)
 
-import qualified Data.Text.Prettyprint.Doc             as Pretty
-import qualified Data.Text.Prettyprint.Doc.Render.Text as Pretty
+import qualified Data.Text.IO                  as Text
 
-import qualified Language.Rust.Parser                  as Rust
-import qualified Language.Rust.Pretty                  as Rust
-import qualified Language.Rust.Quote                   as Rust
-import qualified Language.Rust.Syntax                  as Rust
+import           System.FilePath               ((<.>), (</>))
+import qualified System.IO                     as IO
 
-import           System.FilePath                       ((<.>), (</>))
-import qualified System.IO                             as IO
-
-import qualified Theta.Metadata                        as Theta
-import           Theta.Target.Haskell                  (loadModule)
+import qualified Theta.Metadata                as Theta
+import           Theta.Target.Haskell          (loadModule)
 import           Theta.Target.Rust
-import qualified Theta.Types                           as Theta
+import qualified Theta.Types                   as Theta
 
 import           Test.Tasty
 import           Test.Tasty.HUnit
 
-import qualified Paths_theta                           as Paths
+import qualified Paths_theta                   as Paths
 
 loadModule "test/data/modules" "newtype"
 loadModule "test/data/modules" "recursive"
@@ -48,49 +42,42 @@ tests = testGroup "Rust"
 test_toFile :: TestTree
 test_toFile = testCase "toFile" $ do
   expected <- loadRust "single_file"
-  toFile [theta'newtype, theta'recursive] ?= expected
+  toFile [theta'newtype, theta'recursive] @?= expected
 
 test_toModule :: TestTree
 test_toModule = testGroup "toModule"
   [ testCase "newtype.theta" $ do
       expected <- loadRust "newtype"
-      map render (toModule theta'newtype) @?= items expected
+      toModule theta'newtype @?= [expected]
 
   , testCase "recursive.theta" $ do
       expected <- loadRust "recursive"
-      map render (toModule theta'recursive) @?= items expected
+      toModule theta'recursive @?= [expected]
   ]
-  where items (Rust.SourceFile _ _ i) = render . noSpan <$> i
-
-        render = Pretty.renderStrict . layout . Rust.pretty'
-        layout = Pretty.layoutPretty Pretty.defaultLayoutOptions
 
 test_toReference :: TestTree
 test_toReference = testGroup "toReference"
   [ testCase "primitive types" $ do
-      toReference Theta.bool'     ?= [Rust.ty| bool |]
-      toReference Theta.bytes'    ?= [Rust.ty| Vec<u8> |]
-      toReference Theta.int'      ?= [Rust.ty| i32 |]
-      toReference Theta.long'     ?= [Rust.ty| i64 |]
-      toReference Theta.float'    ?= [Rust.ty| f32 |]
-      toReference Theta.double'   ?= [Rust.ty| f64 |]
-      toReference Theta.date'     ?= [Rust.ty| Date<Utc> |]
-      toReference Theta.datetime' ?= [Rust.ty| DateTime<Utc> |]
+      toReference Theta.bool'     @?= "bool"
+      toReference Theta.bytes'    @?= "Vec<u8>"
+      toReference Theta.int'      @?= "i32"
+      toReference Theta.long'     @?= "i64"
+      toReference Theta.float'    @?= "f32"
+      toReference Theta.double'   @?= "f64"
+      toReference Theta.date'     @?= "Date<Utc>"
+      toReference Theta.datetime' @?= "DateTime<Utc>"
 
   , testCase "containers" $ do
-      toReference (Theta.array' Theta.int')       ?= [Rust.ty| Vec<i32> |]
-      toReference (Theta.array' Theta.string')    ?= [Rust.ty| Vec<String> |]
-      toReference (Theta.map' Theta.int')         ?= [Rust.ty| HashMap<String, i32> |]
-      toReference (Theta.map' Theta.string')      ?= [Rust.ty| HashMap<String, String> |]
-      toReference (Theta.optional' Theta.int')    ?= [Rust.ty| Option<i32> |]
-      toReference (Theta.optional' Theta.string') ?= [Rust.ty| Option<String> |]
+      toReference (Theta.array' Theta.int')       @?= "Vec<i32>"
+      toReference (Theta.array' Theta.string')    @?= "Vec<String>"
+      toReference (Theta.map' Theta.int')         @?= "HashMap<String, i32>"
+      toReference (Theta.map' Theta.string')      @?= "HashMap<String, String>"
+      toReference (Theta.optional' Theta.int')    @?= "Option<i32>"
+      toReference (Theta.optional' Theta.string') @?= "Option<String>"
 
-      toReference (Theta.array' $ Theta.map' Theta.int') ?=
-        [Rust.ty| Vec<HashMap<String, i32>> |]
-      toReference (Theta.map' $ Theta.array' Theta.int') ?=
-        [Rust.ty| HashMap<String, Vec<i32>> |]
-      toReference (Theta.array'$ Theta.optional' Theta.int') ?=
-        [Rust.ty| Vec<Option<i32>> |]
+      toReference (Theta.array' $ Theta.map' Theta.int')     @?= "Vec<HashMap<String, i32>>"
+      toReference (Theta.map' $ Theta.array' Theta.int')     @?= "HashMap<String, Vec<i32>>"
+      toReference (Theta.array'$ Theta.optional' Theta.int') @?= "Vec<Option<i32>>"
 
   , testCase "named types" $ do
       let reference = wrap $ Theta.Reference' "base.FooReference"
@@ -99,162 +86,140 @@ test_toReference = testGroup "toReference"
             [ Theta.Case "base.Foo" Nothing [] ]
           newtype_  = wrap $ Theta.Newtype' "base.FooNewtype" record
 
-      toReference reference ?= [Rust.ty| base::FooReference |]
-      toReference record    ?= [Rust.ty| base::FooRecord |]
-      toReference variant   ?= [Rust.ty| base::FooVariant |]
-      toReference newtype_  ?= [Rust.ty| base::FooNewtype |]
+      toReference reference @?= "base::FooReference"
+      toReference record    @?= "base::FooRecord"
+      toReference variant   @?= "base::FooVariant"
+      toReference newtype_  @?= "base::FooNewtype"
   ]
   where wrap = Theta.withModule' Theta.baseModule
 
 test_toRecord :: TestTree
 test_toRecord = testGroup "toRecord"
   [ testCase "empty record" $ do
-      toRecord "foo.Empty" [] ??=
-        [ [Rust.item|
-           #[derive(Clone, Debug, PartialEq)]
-           pub struct Empty {}
-          |]
+      toRecord "foo.Empty" [] @?=
+        [rust|
+          #[derive(Clone, Debug, PartialEq)]
+          pub struct Empty {}
 
-        , [Rust.item|
-           impl ToAvro for Empty {
-             fn to_avro_buffer(&self, buffer: &mut Vec<u8>) {
+          impl ToAvro for Empty {
+            fn to_avro_buffer(&self, buffer: &mut Vec<u8>) {
+            }
+          }
+
+          impl FromAvro for Empty {
+             fn from_avro(input: &[u8]) -> IResult<&[u8], Self> {
+               context("foo.Empty", |input| {
+                 Ok((input, Empty {}))
+               })(input)
              }
-           }
-          |]
-
-        , [Rust.item|
-           impl FromAvro for Empty {
-              fn from_avro(input: &[u8]) -> IResult<&[u8], Self> {
-                context("foo.Empty", |input| {
-                  Ok((input, Empty {}))
-                })(input)
-              }
-           }
-          |]
-        ]
+          }
+        |]
+        
 
   , testCase "simple types" $ do
       let foo = Theta.Field "foo" Nothing Theta.int'
           input = Theta.Field "input" Nothing Theta.string'
           -- fields named "input" need special handling
 
-      toRecord "foo.OneField" [foo] ??=
-        [ [Rust.item|
-           #[derive(Clone, Debug, PartialEq)]
-           pub struct OneField {
-              pub foo: i32,
-           }
-          |]
+      toRecord "foo.OneField" [foo] @?=
+        [rust|
+          #[derive(Clone, Debug, PartialEq)]
+          pub struct OneField {
+             pub foo: i32,
+          }
 
-        , [Rust.item|
-           impl ToAvro for OneField {
-             fn to_avro_buffer(&self, buffer: &mut Vec<u8>) {
-               self.foo.to_avro_buffer(buffer);
+          impl ToAvro for OneField {
+            fn to_avro_buffer(&self, buffer: &mut Vec<u8>) {
+              self.foo.to_avro_buffer(buffer);
+            }
+          }
+
+          impl FromAvro for OneField {
+             fn from_avro(input: &[u8]) -> IResult<&[u8], Self> {
+               context("foo.OneField", |input| {
+                   let (input, foo) = i32::from_avro(input)?;
+                   Ok((input, OneField { foo }))
+               })(input)
              }
-           }
-          |]
+          }
+        |]
+        
 
-        , [Rust.item|
-           impl FromAvro for OneField {
-              fn from_avro(input: &[u8]) -> IResult<&[u8], Self> {
-                context("foo.OneField", |input| {
-                    let (input, foo) = i32::from_avro(input)?;
-                    Ok((input, OneField { foo }))
-                })(input)
-              }
-           }
-          |]
-        ]
+      toRecord "foo.TwoFields" [foo, input] @?=
+        [rust|
+          #[derive(Clone, Debug, PartialEq)]
+          pub struct TwoFields {
+             pub foo: i32,
+             pub input: String,
+          }
 
-      toRecord "foo.TwoFields" [foo, input] ??=
-        [ [Rust.item|
-           #[derive(Clone, Debug, PartialEq)]
-           pub struct TwoFields {
-              pub foo: i32,
-              pub input: String,
-           }
-          |]
+          impl ToAvro for TwoFields {
+            fn to_avro_buffer(&self, buffer: &mut Vec<u8>) {
+              self.foo.to_avro_buffer(buffer);
+              self.input.to_avro_buffer(buffer);
+            }
+          }
 
-        , [Rust.item|
-           impl ToAvro for TwoFields {
-             fn to_avro_buffer(&self, buffer: &mut Vec<u8>) {
-               self.foo.to_avro_buffer(buffer);
-               self.input.to_avro_buffer(buffer);
+          impl FromAvro for TwoFields {
+             fn from_avro(input: &[u8]) -> IResult<&[u8], Self> {
+               context("foo.TwoFields", |input| {
+                 let (input, foo) = i32::from_avro(input)?;
+                 let (input, __input__) = String::from_avro(input)?;
+                 Ok((input, TwoFields { foo, input: __input__ }))
+               })(input)
              }
-           }
-          |]
-
-        , [Rust.item|
-           impl FromAvro for TwoFields {
-              fn from_avro(input: &[u8]) -> IResult<&[u8], Self> {
-                context("foo.TwoFields", |input| {
-                  let (input, foo) = i32::from_avro(input)?;
-                  let (input, __input__) = String::from_avro(input)?;
-                  Ok((input, TwoFields { foo, input: __input__ }))
-                })(input)
-              }
-           }
-          |]
-        ]
+          }
+        |]
+        
 
   , testCase "references" $ do
       let foo = Theta.Field "foo" Nothing (reference "foo.Foo")
-      toRecord "foo.Foo" [foo] ??=
-        [ [Rust.item|
-           #[derive(Clone, Debug, PartialEq)]
-           pub struct Foo {
-              pub foo: Box<foo::Foo>,
-           }
-          |]
+      toRecord "foo.Foo" [foo] @?=
+        [rust|
+          #[derive(Clone, Debug, PartialEq)]
+          pub struct Foo {
+             pub foo: Box<foo::Foo>,
+          }
 
-        , [Rust.item|
-           impl ToAvro for Foo {
-             fn to_avro_buffer(&self, buffer: &mut Vec<u8>) {
-               self.foo.to_avro_buffer(buffer);
+          impl ToAvro for Foo {
+            fn to_avro_buffer(&self, buffer: &mut Vec<u8>) {
+              self.foo.to_avro_buffer(buffer);
+            }
+          }
+
+          impl FromAvro for Foo {
+             fn from_avro(input: &[u8]) -> IResult<&[u8], Self> {
+               context("foo.Foo", |input| {
+                 let (input, foo) = foo::Foo::from_avro(input)?;
+                 Ok((input, Foo { foo: Box::new(foo) }))
+               })(input)
              }
-           }
-          |]
+          }
+        |]
+        
 
-        , [Rust.item|
-           impl FromAvro for Foo {
-              fn from_avro(input: &[u8]) -> IResult<&[u8], Self> {
-                context("foo.Foo", |input| {
-                  let (input, foo) = foo::Foo::from_avro(input)?;
-                  Ok((input, Foo { foo: Box::new(foo) }))
-                })(input)
-              }
-           }
-          |]
-        ]
+      toRecord "foo.Bar" [foo] @?=
+        [rust|
+          #[derive(Clone, Debug, PartialEq)]
+          pub struct Bar {
+             pub foo: foo::Foo,
+          }
 
-      toRecord "foo.Bar" [foo] ??=
-        [ [Rust.item|
-           #[derive(Clone, Debug, PartialEq)]
-           pub struct Bar {
-              pub foo: foo::Foo,
-           }
-          |]
+          impl ToAvro for Bar {
+            fn to_avro_buffer(&self, buffer: &mut Vec<u8>) {
+              self.foo.to_avro_buffer(buffer);
+            }
+          }
 
-        , [Rust.item|
-           impl ToAvro for Bar {
-             fn to_avro_buffer(&self, buffer: &mut Vec<u8>) {
-               self.foo.to_avro_buffer(buffer);
+          impl FromAvro for Bar {
+             fn from_avro(input: &[u8]) -> IResult<&[u8], Self> {
+               context("foo.Bar", |input| {
+                 let (input, foo) = foo::Foo::from_avro(input)?;
+                 Ok((input, Bar { foo }))
+               })(input)
              }
-           }
-          |]
-
-
-        , [Rust.item|
-           impl FromAvro for Bar {
-              fn from_avro(input: &[u8]) -> IResult<&[u8], Self> {
-                context("foo.Bar", |input| {
-                  let (input, foo) = foo::Foo::from_avro(input)?;
-                  Ok((input, Bar { foo }))
-                })(input)
-              }
-           }
-          |]
-        ]
+          }
+        |]
   ]
   where reference = Theta.withModule' Theta.baseModule . Theta.Reference'
 
@@ -262,17 +227,15 @@ test_toVariant :: TestTree
 test_toVariant = testGroup "toVariant"
   [ testCase "single case" $ do
       let cases = [Theta.Case "foo.Case" Nothing [Theta.Field "foo" Nothing Theta.int']]
-      toVariant "foo.Variant" cases ??=
-        [[Rust.item|
+      toVariant "foo.Variant" cases @?=
+        [rust|
           #[derive(Clone, Debug, PartialEq)]
           pub enum Variant {
              Case {
                 foo: i32,
              },
           }
-         |]
 
-        , [Rust.item|
            impl ToAvro for Variant {
              fn to_avro_buffer(&self, buffer: &mut Vec<u8>) {
                match self {
@@ -283,9 +246,7 @@ test_toVariant = testGroup "toVariant"
                };
              }
            }
-          |]
 
-        , [Rust.item|
            impl FromAvro for Variant {
              fn from_avro(input: &[u8]) -> IResult<&[u8], Self> {
                context("foo.Variant", |input| {
@@ -300,17 +261,16 @@ test_toVariant = testGroup "toVariant"
                })(input)
              }
            }
-          |]
-        ]
-
+        |]
+        
   , testCase "two cases" $ do
       let cases = [ Theta.Case "foo.One" Nothing [ Theta.Field "foo"   Nothing Theta.int' ]
                   , Theta.Case "foo.Two" Nothing [ Theta.Field "foo"   Nothing Theta.int'
                                                  , Theta.Field "input" Nothing Theta.string'
                                                  ]
                   ]
-      toVariant "foo.Variant" cases ??=
-        [[Rust.item|
+      toVariant "foo.Variant" cases @?=
+        [rust|
           #[derive(Clone, Debug, PartialEq)]
           pub enum Variant {
              One {
@@ -321,133 +281,112 @@ test_toVariant = testGroup "toVariant"
                  input: String,
              },
           }
-         |]
 
+          impl ToAvro for Variant {
+            fn to_avro_buffer(&self, buffer: &mut Vec<u8>) {
+              match self {
+                Variant::One { foo } => {
+                  0i64.to_avro_buffer(buffer);
+                  foo.to_avro_buffer(buffer);
+                },
+                Variant::Two { foo, input } => {
+                  1i64.to_avro_buffer(buffer);
+                  foo.to_avro_buffer(buffer);
+                  input.to_avro_buffer(buffer);
+                },
+              };
+            }
+          }
 
-        , [Rust.item|
-           impl ToAvro for Variant {
-             fn to_avro_buffer(&self, buffer: &mut Vec<u8>) {
-               match self {
-                 Variant::One { foo } => {
-                   0i64.to_avro_buffer(buffer);
-                   foo.to_avro_buffer(buffer);
-                 },
-                 Variant::Two { foo, input } => {
-                   1i64.to_avro_buffer(buffer);
-                   foo.to_avro_buffer(buffer);
-                   input.to_avro_buffer(buffer);
-                 },
-               };
-             }
-           }
-          |]
-
-        , [Rust.item|
-           impl FromAvro for Variant {
-             fn from_avro(input: &[u8]) -> IResult<&[u8], Self> {
-               context("foo.Variant", |input| {
-                 let (input, tag) = i64::from_avro(input)?;
-                 match tag {
-                   0 => {
-                     let (input, foo) = i32::from_avro(input)?;
-                     Ok((input, Variant::One { foo }))
-                   },
-                   1 => {
-                     let (input, foo) = i32::from_avro(input)?;
-                     let (input, __input__) = String::from_avro(input)?;
-                     Ok((input, Variant::Two { foo, input: __input__ }))
-                   },
-                   _ => Err(Err::Error((input, ErrorKind::Tag))),
-                 }
-               })(input)
-             }
-           }
-          |]
-        ]
+          impl FromAvro for Variant {
+            fn from_avro(input: &[u8]) -> IResult<&[u8], Self> {
+              context("foo.Variant", |input| {
+                let (input, tag) = i64::from_avro(input)?;
+                match tag {
+                  0 => {
+                    let (input, foo) = i32::from_avro(input)?;
+                    Ok((input, Variant::One { foo }))
+                  },
+                  1 => {
+                    let (input, foo) = i32::from_avro(input)?;
+                    let (input, __input__) = String::from_avro(input)?;
+                    Ok((input, Variant::Two { foo, input: __input__ }))
+                  },
+                  _ => Err(Err::Error((input, ErrorKind::Tag))),
+                }
+              })(input)
+            }
+          }
+        |]
   ]
 
 test_toNewtype :: TestTree
 test_toNewtype = testGroup "toNewtype"
   [ testCase "primitive" $ do
-      toNewtype "foo.Foo" Theta.int' ??=
-        [ [Rust.item|
-           #[derive(Copy, Clone, Debug, PartialEq)]
-           pub struct Foo(pub i32);
-          |]
+      toNewtype "foo.Foo" Theta.int' @?=
+       [rust|
+         #[derive(Copy, Clone, Debug, PartialEq)]
+         pub struct Foo(pub i32);
 
-       , [Rust.item|
-          impl ToAvro for Foo {
-             fn to_avro_buffer(&self, buffer: &mut Vec<u8>) {
-               self.0.to_avro_buffer(buffer);
-             }
-          }
-         |]
-
-       , [Rust.item|
-          impl FromAvro for Foo {
-            fn from_avro(input: &[u8]) -> IResult<&[u8], Self> {
-              context("foo.Foo", |input| {
-                let (input, value) = i32::from_avro(input)?;
-                Ok((input, Foo(value)))
-              })(input)
+         impl ToAvro for Foo {
+            fn to_avro_buffer(&self, buffer: &mut Vec<u8>) {
+              self.0.to_avro_buffer(buffer);
             }
-          }
-         |]
-       ]
+         }
 
+         impl FromAvro for Foo {
+           fn from_avro(input: &[u8]) -> IResult<&[u8], Self> {
+             context("foo.Foo", |input| {
+               let (input, value) = i32::from_avro(input)?;
+               Ok((input, Foo(value)))
+             })(input)
+           }
+         }
+       |]
+       
   , testCase "reference" $ do
-      toNewtype "foo.Foo" (reference "foo.Bar") ??=
-        [[Rust.item|
+      toNewtype "foo.Foo" (reference "foo.Bar") @?=
+       [rust|
          #[derive(Copy, Clone, Debug, PartialEq)]
          pub struct Foo(pub foo::Bar);
-         |]
 
-       , [Rust.item|
-          impl ToAvro for Foo {
-             fn to_avro_buffer(&self, buffer: &mut Vec<u8>) {
-               self.0.to_avro_buffer(buffer);
-             }
-          }
-         |]
-
-       , [Rust.item|
-          impl FromAvro for Foo {
-            fn from_avro(input: &[u8]) -> IResult<&[u8], Self> {
-              context("foo.Foo", |input| {
-                let (input, value) = foo::Bar::from_avro(input)?;
-                Ok((input, Foo(value)))
-              })(input)
+         impl ToAvro for Foo {
+            fn to_avro_buffer(&self, buffer: &mut Vec<u8>) {
+              self.0.to_avro_buffer(buffer);
             }
-          }
-         |]
-        ]
+         }
+
+         impl FromAvro for Foo {
+           fn from_avro(input: &[u8]) -> IResult<&[u8], Self> {
+             context("foo.Foo", |input| {
+               let (input, value) = foo::Bar::from_avro(input)?;
+               Ok((input, Foo(value)))
+             })(input)
+           }
+         }
+       |]
 
   , testCase "container" $ do
-     toNewtype "foo.Foo" (Theta.array' Theta.double') ??=
-       [[Rust.item|
+     toNewtype "foo.Foo" (Theta.array' Theta.double') @?=
+       [rust|
          #[derive(Clone, Debug, PartialEq)]
          pub struct Foo(pub Vec<f64>);
-        |]
 
-       , [Rust.item|
-          impl ToAvro for Foo {
-             fn to_avro_buffer(&self, buffer: &mut Vec<u8>) {
-               self.0.to_avro_buffer(buffer);
-             }
-          }
-         |]
-
-       , [Rust.item|
-          impl FromAvro for Foo {
-            fn from_avro(input: &[u8]) -> IResult<&[u8], Self> {
-              context("foo.Foo", |input| {
-                let (input, value) = Vec::from_avro(input)?;
-                Ok((input, Foo(value)))
-              })(input)
+         impl ToAvro for Foo {
+            fn to_avro_buffer(&self, buffer: &mut Vec<u8>) {
+              self.0.to_avro_buffer(buffer);
             }
-          }
-         |]
-      ]
+         }
+
+         impl FromAvro for Foo {
+           fn from_avro(input: &[u8]) -> IResult<&[u8], Self> {
+             context("foo.Foo", |input| {
+               let (input, value) = Vec::from_avro(input)?;
+               Ok((input, Foo(value)))
+             })(input)
+           }
+         }
+       |]
   ]
   where reference = Theta.withModule'  fooModule . Theta.Reference'
         fooModule = Theta.Module "foo"
@@ -458,22 +397,16 @@ test_toNewtype = testGroup "toNewtype"
 test_alias :: TestTree
 test_alias = testGroup "alias"
   [ testCase "primitive" $ do
-      toDefinition (Theta.Definition "foo.Foo" Nothing Theta.int') ??=
-        [[Rust.item|
-         pub type Foo = i32;
-         |]]
+      toDefinition (Theta.Definition "foo.Foo" Nothing Theta.int') @?=
+        "pub type Foo = i32;"
 
   , testCase "reference" $ do
-      toDefinition (Theta.Definition "foo.Foo" Nothing (reference "foo.Bar")) ??=
-        [[Rust.item|
-         pub type Foo = foo::Bar;
-         |]]
+      toDefinition (Theta.Definition "foo.Foo" Nothing (reference "foo.Bar")) @?=
+        "pub type Foo = foo::Bar;"
 
   , testCase "container" $ do
-     toDefinition (Theta.Definition "foo.Foo" Nothing (Theta.array' Theta.double')) ??=
-       [[Rust.item|
-         pub type Foo = Vec<f64>;
-        |]]
+     toDefinition (Theta.Definition "foo.Foo" Nothing (Theta.array' Theta.double')) @?=
+       "pub type Foo = Vec<f64>;"
   ]
   where reference = Theta.withModule' fooModule . Theta.Reference'
         fooModule = Theta.Module
@@ -484,31 +417,10 @@ test_alias = testGroup "alias"
           , Theta.metadata   = Theta.Metadata "1.0.0" "1.0.0" "foo"
           }
 
--- | Helper function for comparing a generated AST fragment against
--- one produced by a quasiquoter.
---
--- Comparing ASTs directly was causing problems with different
--- 'Rust.Span' values, so this pretty-prints both ASTs and compares
--- the result.
-(?=) :: (Functor f, Rust.Resolve (f ()), Rust.Pretty (f ()))
-     => f () -> f a -> Assertion
-got ?= expected = render got @?= render (noSpan expected)
-  where render = Pretty.renderStrict . layout . Rust.pretty'
-        layout = Pretty.layoutPretty Pretty.defaultLayoutOptions
-
--- | Like (?=) but for lists of values.
-(??=) :: (Functor f, Rust.Resolve (f ()), Rust.Pretty (f ()))
-      => [f ()] -> [f a] -> Assertion
-got ??= expected
-  | length got == length expected = zipWithM_ (?=) got expected
-  | otherwise = error "Mismatch in list length.\n\
-                      \You're probably missing or generating an extra impl block \
-                      \or something."
-
--- | Load a @.rs@ file with the given base name (without the @.rs@)
--- from @test/data/rust@.
-loadRust :: String -> IO (Rust.SourceFile Rust.Span)
+-- | Load a @.rs@ file with the given base name (adding the @.rs@
+-- extension) from @test/data/rust@.
+loadRust :: String -> IO Rust
 loadRust name = do
   dataDir <- Paths.getDataDir
   let path = dataDir </> "test/data/rust" </> name <.> "rs"
-  Rust.readSourceFile =<< IO.openFile path IO.ReadMode
+  Rust <$> Text.readFile path

--- a/theta/test/data/rust/newtype.rs
+++ b/theta/test/data/rust/newtype.rs
@@ -36,7 +36,7 @@ impl FromAvro for NewtypeRecord {
     fn from_avro(input: &[u8]) -> IResult<&[u8], Self> {
         context("newtype.NewtypeRecord", |input| {
             let (input, foo) = newtype::Newtype::from_avro(input)?;
-            Ok((input, NewtypeRecord { foo }))
+            Ok((input, NewtypeRecord { foo: foo }))
         })(input)
     }
 }

--- a/theta/test/data/rust/recursive.rs
+++ b/theta/test/data/rust/recursive.rs
@@ -63,7 +63,8 @@ impl FromAvro for MutualB {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Recursive {
-    Nil {},
+    Nil {
+    },
     Recurse {
         contents: i32,
         boxed: Box<recursive::Recursive>,
@@ -74,7 +75,7 @@ pub enum Recursive {
 impl ToAvro for Recursive {
   fn to_avro_buffer(&self, buffer: &mut Vec<u8>) {
     match self {
-      Recursive::Nil {} => {
+      Recursive::Nil {  } => {
         0i64.to_avro_buffer(buffer);
       },
 
@@ -94,13 +95,13 @@ impl FromAvro for Recursive {
       let (input, tag) = i64::from_avro(input)?;
       match tag {
         0 => {
-          Ok((input, Recursive::Nil{}))
+          Ok((input, Recursive::Nil {  }))
         },
         1 => {
           let (input, contents) = i32::from_avro(input)?;
           let (input, boxed) = recursive::Recursive::from_avro(input)?;
           let (input, unboxed) = HashMap::from_avro(input)?;
-          Ok((input, Recursive::Recurse { contents, boxed: Box::new(boxed), unboxed }))
+          Ok((input, Recursive::Recurse { contents: contents, boxed: Box::new(boxed), unboxed: unboxed }))
         },
         _ => Err(Err::Error((input, ErrorKind::Tag))),
       }

--- a/theta/test/data/rust/single_file.rs
+++ b/theta/test/data/rust/single_file.rs
@@ -43,7 +43,7 @@ pub mod newtype {
         fn from_avro(input: &[u8]) -> IResult<&[u8], Self> {
             context("newtype.NewtypeRecord", |input| {
                 let (input, foo) = newtype::Newtype::from_avro(input)?;
-                Ok((input, NewtypeRecord { foo }))
+                Ok((input, NewtypeRecord { foo: foo }))
             })(input)
         }
     }
@@ -118,7 +118,8 @@ pub mod recursive {
 
     #[derive(Clone, Debug, PartialEq)]
     pub enum Recursive {
-        Nil {},
+        Nil {
+        },
         Recurse {
             contents: i32,
             boxed: Box<recursive::Recursive>,
@@ -129,7 +130,7 @@ pub mod recursive {
     impl ToAvro for Recursive {
         fn to_avro_buffer(&self, buffer: &mut Vec<u8>) {
             match self {
-                Recursive::Nil {} => {
+                Recursive::Nil {  } => {
                     0i64.to_avro_buffer(buffer);
                 },
                 Recursive::Recurse { contents, boxed, unboxed } => {
@@ -148,13 +149,13 @@ pub mod recursive {
                 let (input, tag) = i64::from_avro(input)?;
                 match tag {
                     0 => {
-                        Ok((input, Recursive::Nil{}))
+                        Ok((input, Recursive::Nil {  }))
                     },
                     1 => {
                         let (input, contents) = i32::from_avro(input)?;
                         let (input, boxed) = recursive::Recursive::from_avro(input)?;
                         let (input, unboxed) = HashMap::from_avro(input)?;
-                        Ok((input, Recursive::Recurse { contents, boxed: Box::new(boxed), unboxed }))
+                        Ok((input, Recursive::Recurse { contents: contents, boxed: Box::new(boxed), unboxed: unboxed }))
                     },
                     _ => Err(Err::Error((input, ErrorKind::Tag))),
                 }

--- a/theta/theta.cabal
+++ b/theta/theta.cabal
@@ -113,7 +113,7 @@ test-suite tests
                     , Test.Theta.Target.Python
                     , Test.Theta.Target.Python.QuasiQuoter
 
-                    -- , Test.Theta.Target.Rust
+                    , Test.Theta.Target.Rust
 
                     , Paths_theta
 

--- a/theta/theta.cabal
+++ b/theta/theta.cabal
@@ -120,6 +120,7 @@ test-suite tests
   build-depends:      theta
 
                     , directory
+                    , Diff
                     , stache
 
                     , tasty


### PR DESCRIPTION
About a year ago, I made some changes to the Rust code in order to stop depending on `language-rust` which was unmaintained and causing build issues[^1]. However, I didn't finish those changes before merging them in—don't remember why—so the tests for the Rust code generation didn't build at all and the code itself had some bugs.

This PR fixes both of these problems:

  1. The tests use the new string-based interpolation style
  2. I fixed the resulting bugs—mostly issues with the test suite, but a few logical Rust problems as well
  
The resulting code passes the cross-language tests, so it should be in pretty good shape.

[^1]: Also, I've realized that for code generation *specifically*, using a structured code representation has too much overhead. Templating is limited to a few specific parts of the language (eg expressions or statements), so a lot of code has to build code fragments “by hand” which is a real pain to write, maintain and modify. I've thought about what it would take to have  structured library with flexible templating, but I haven't been able to figure out a reasonable approach.

    Practical upside: generating code as strings with a decent templating solution turns out to be a **much better* choice overall.