### PR TITLE
Put logical date and timestamp-micros types behind version gate

### DIFF
--- a/theta/src/Theta/Target/Avro/Values.hs
+++ b/theta/src/Theta/Target/Avro/Values.hs
@@ -58,6 +58,7 @@ import           GHC.Exts                    (fromList)
 
 import           Theta.Error                 (Error)
 import qualified Theta.Error                 as Error
+import qualified Theta.Metadata              as Metadata
 import           Theta.Name                  (Name)
 import qualified Theta.Name                  as Name
 import           Theta.Target.Avro.Error
@@ -77,7 +78,8 @@ trace' label a = trace (label <> ":\n" <> show a <> "\n") a
 -- the Theta type of the value, as compiled by 'toSchema'.
 toAvro :: MonadError Error m => Value -> m Avro.Value
 toAvro value@Value { type_ } = do
-  !schema <- evalStateT (typeToAvro type_) Set.empty
+  let avroVersion = Metadata.avroVersion $ Theta.metadata $ Theta.module_ type_
+  !schema <- evalStateT (typeToAvro avroVersion type_) Set.empty
 
   let env      = runIdentity . Schema.buildTypeEnvironment die schema
       die name = error $ show name <> " not defined in generated Avro schema."

--- a/theta/src/Theta/Target/Haskell.hs
+++ b/theta/src/Theta/Target/Haskell.hs
@@ -524,9 +524,12 @@ hasThetaInstance moduleName definitionName =
 hasAvroInstance :: Name.Name -> Q [Dec]
 hasAvroInstance (toName -> type_) =
   [d| instance HasAvroSchema $(conT type_) where
-        schema = Tagged $ case evalStateT (typeToAvro $ theta @ $(conT type_)) Set.empty of
+        schema = Tagged $ case evalStateT toAvro Set.empty of
           Left err  -> error $ Text.unpack $ Theta.pretty err
           Right res -> res
+          where toAvro                = typeToAvro definitionAvroVersion thetaType
+                thetaType             = theta @ $(conT type_)
+                definitionAvroVersion = avroVersion $ Theta.metadata $ Theta.module_ thetaType
     |]
 
 -- | Generate a 'Avro.ToAvro' instance for the type. This might

--- a/theta/test/data/modules/logical_dates.theta
+++ b/theta/test/data/modules/logical_dates.theta
@@ -1,0 +1,20 @@
+language-version: 1.0.0
+avro-version: 1.1.0
+---
+
+import primitives
+
+// We started using Avro's logical "date" and "timestamp-micros" types in
+// avro-version 1.2.0
+//
+// This doesn't change the semantics of the
+// encoding—the binary produced is identical—but it changes the generated
+// schemas.
+type Dates = {
+  logical_date: Date,
+  logical_datetime: Datetime,
+
+  // The date and datetime fields in Primtives should *not* use
+  // logical types since that module has avro-version set to 1.0.0
+  primitives: primitives.Primitives
+}

--- a/theta/test/data/modules/primitives.theta
+++ b/theta/test/data/modules/primitives.theta
@@ -12,8 +12,8 @@ type Primitives = {
   float    : Float,
   double   : Double,
   string   : String,
-  date     : Date,    // since 1.2.0
-  datetime : Datetime // since 1.2.0
+  date     : Date,
+  datetime : Datetime
 }
 
 type Containers = {


### PR DESCRIPTION
After this PR:

  * `avro-version` < 1.1.0: `Date` → `int`, `Datetime` → `long`
  * `avro-version` ≥ 1.1.0: `Date` → `date`, `Datetime` → `timestamp-micros`

This is a change to the generated Avro schemas only—the binary encoding and semantics don't change.