### PR TITLE
Update code to work with versions package >5.0.0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": null,
         "owner": "commercialhaskell",
         "repo": "all-cabal-hashes",
-        "rev": "55f0640818e41a97c3090e6c671f6f50654ca11d",
-        "sha256": "04hjlblmyqkzhz073mvbyg9chr5jrvxzk2whk4hh6mw1pjs8l10z",
+        "rev": "648effa545704bd1af1136eef49dc5411975c143",
+        "sha256": "1ci9344bh166j2ibbzdprpr6h1zwmxln968aj8w7g5n6dbni8p68",
         "type": "file",
-        "url": "https://github.com/commercialhaskell/all-cabal-hashes/archive/55f0640818e41a97c3090e6c671f6f50654ca11d.tar.gz",
+        "url": "https://github.com/commercialhaskell/all-cabal-hashes/archive/648effa545704bd1af1136eef49dc5411975c143.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "language-rust": {

--- a/theta/default.nix
+++ b/theta/default.nix
@@ -3,8 +3,8 @@
 , pkgs ? import ../nix/nixpkgs.nix { inherit sources;}
 , compiler ? pkgs.haskell.packages."${compiler-version}"
 , source-overrides ? {
-  avro = "0.5.2.0";
-  string-interpolate = "0.2.1.0";
+  avro = "0.5.2.1";
+  versions = "5.0.2";
 }
 , werror ? true
 }:

--- a/theta/src/Theta/Metadata.hs
+++ b/theta/src/Theta/Metadata.hs
@@ -1,89 +1,81 @@
-{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
-{- | This module defines types for handling version metadata in Theta
- schemas.
-
- Each Theta schema starts with a section that specifies the version
- of the language and Avro encoding the schema expects:
-
- @
- language-version: 1.0.0
- avro-version: 1.2.0
- ---
- @
-
- Theta then guarantees that two identical schemas that specify the
- same language and encoding version will produce compatible Avro
- schemas and objects with different versions—or even different
- /implementations/—of the Theta compiler.
--}
+-- | This module defines types for handling version metadata in Theta
+-- schemas.
+--
+-- Each Theta schema starts with a section that specifies the version
+-- of the language and Avro encoding the schema expects:
+--
+-- @
+-- language-version: 1.0.0
+-- avro-version: 1.2.0
+-- ---
+-- @
+--
+-- Theta then guarantees that two identical schemas that specify the
+-- same language and encoding version will produce compatible Avro
+-- schemas and objects with different versions—or even different
+-- /implementations/—of the Theta compiler.
 module Theta.Metadata where
 
-import qualified Data.Text as Text
-import Data.Versions (SemVer (..), prettySemVer, semver)
+import qualified Data.Text       as Text
+import           Data.Versions   (SemVer (..), prettySemVer, semver)
 
-import GHC.Exts (IsString (..))
+import           GHC.Exts        (IsString (..))
 
-import Test.QuickCheck (Arbitrary (arbitrary))
+import           Test.QuickCheck (Arbitrary (arbitrary))
 
-import Text.Megaparsec (errorBundlePretty)
+import           Text.Megaparsec (errorBundlePretty)
 
-import Data.Foldable (Foldable (toList))
-import qualified Theta.Name as Name
-import Theta.Pretty (Pretty (..))
+import qualified Theta.Name      as Name
+import           Theta.Pretty    (Pretty (..))
 
 -- | The data included in a module's metadata section.
 data Metadata = Metadata
-    { -- | The version of the Theta language determines what language
-      -- features the schema can use and how those features work.
-      languageVersion :: Version
-    , -- | The Avro version determines how a schema is converted to
-      -- Avro. The same schema compiled at the same Avro version should
-      -- always generate compatible Avro data.
-      avroVersion :: Version
-    , -- | The name of the module that this section belongs to.
-      moduleName :: Name.ModuleName
-    }
-    deriving (Show, Eq)
+  { languageVersion :: Version
+    -- ^ The version of the Theta language determines what language
+    -- features the schema can use and how those features work.
+  , avroVersion     :: Version
+    -- ^ The Avro version determines how a schema is converted to
+    -- Avro. The same schema compiled at the same Avro version should
+    -- always generate compatible Avro data.
+  , moduleName      :: Name.ModuleName
+    -- ^ The name of the module that this section belongs to.
+  } deriving (Show, Eq)
 
 instance Arbitrary Metadata where
-    arbitrary = Metadata <$> arbitrary <*> arbitrary <*> arbitrary
+  arbitrary = Metadata <$> arbitrary <*> arbitrary <*> arbitrary
 
-{- | A semantic version that's compliant with the semver spec.
-
- This is just a wrapper over 'SemVer' that lets me add typeclass
- instances.
--}
+-- | A semantic version that's compliant with the semver spec.
+--
+-- This is just a wrapper over 'SemVer' that lets me add typeclass
+-- instances.
 newtype Version = Version SemVer
-    deriving newtype (Show, Eq, Ord)
+  deriving newtype (Show, Eq, Ord)
 
 instance Arbitrary Version where
-    arbitrary = Version <$> semver
-      where
-        semver =
-            SemVer <$> arbitrary
-                <*> arbitrary
-                <*> arbitrary
-                <*> pure []
-                <*> pure Nothing
+  arbitrary = Version <$> semver
+    where semver = SemVer <$> arbitrary
+                          <*> arbitrary
+                          <*> arbitrary
+                          <*> pure []
+                          <*> pure Nothing
 
-{- | Render a 'Version' in a compact, human-readable format.
-
- @
- λ> show ("1.2.1" :: Version)
- "SemVer {_svMajor = 1, _svMinor = 2, _svPatch = 1, _svPreRel = [], _svMeta = []}"
- λ> pretty ("1.2.1" :: Version)
- "1.2.1"
- @
--}
+-- | Render a 'Version' in a compact, human-readable format.
+--
+-- @
+-- λ> show ("1.2.1" :: Version)
+-- "SemVer {_svMajor = 1, _svMinor = 2, _svPatch = 1, _svPreRel = [], _svMeta = []}"
+-- λ> pretty ("1.2.1" :: Version)
+-- "1.2.1"
+-- @
 instance Pretty Version where
-    pretty (Version semVer) = prettySemVer semVer
+  pretty (Version semVer) = prettySemVer semVer
 
-{- | Turns a literal "1.2.0" into a 'Version'. Errors out if the
- format is not compliant with semver.
--}
+-- | Turns a literal "1.2.0" into a 'Version'. Errors out if the
+-- format is not compliant with semver.
 instance IsString Version where
-    fromString str = case semver (Text.pack str) of
-        Left parseError -> error $ errorBundlePretty parseError
-        Right version -> Version version
+  fromString str = case semver (Text.pack str) of
+    Left parseError -> error $ errorBundlePretty parseError
+    Right version   -> Version version

--- a/theta/src/Theta/Metadata.hs
+++ b/theta/src/Theta/Metadata.hs
@@ -1,81 +1,89 @@
-{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
--- | This module defines types for handling version metadata in Theta
--- schemas.
---
--- Each Theta schema starts with a section that specifies the version
--- of the language and Avro encoding the schema expects:
---
--- @
--- language-version: 1.0.0
--- avro-version: 1.2.0
--- ---
--- @
---
--- Theta then guarantees that two identical schemas that specify the
--- same language and encoding version will produce compatible Avro
--- schemas and objects with different versions—or even different
--- /implementations/—of the Theta compiler.
+{- | This module defines types for handling version metadata in Theta
+ schemas.
+
+ Each Theta schema starts with a section that specifies the version
+ of the language and Avro encoding the schema expects:
+
+ @
+ language-version: 1.0.0
+ avro-version: 1.2.0
+ ---
+ @
+
+ Theta then guarantees that two identical schemas that specify the
+ same language and encoding version will produce compatible Avro
+ schemas and objects with different versions—or even different
+ /implementations/—of the Theta compiler.
+-}
 module Theta.Metadata where
 
-import qualified Data.Text       as Text
-import           Data.Versions   (SemVer (..), prettySemVer, semver)
+import qualified Data.Text as Text
+import Data.Versions (SemVer (..), prettySemVer, semver)
 
-import           GHC.Exts        (IsString (..))
+import GHC.Exts (IsString (..))
 
-import           Test.QuickCheck (Arbitrary (arbitrary))
+import Test.QuickCheck (Arbitrary (arbitrary))
 
-import           Text.Megaparsec (errorBundlePretty)
+import Text.Megaparsec (errorBundlePretty)
 
-import qualified Theta.Name      as Name
-import           Theta.Pretty    (Pretty (..))
+import Data.Foldable (Foldable (toList))
+import qualified Theta.Name as Name
+import Theta.Pretty (Pretty (..))
 
 -- | The data included in a module's metadata section.
 data Metadata = Metadata
-  { languageVersion :: Version
-    -- ^ The version of the Theta language determines what language
-    -- features the schema can use and how those features work.
-  , avroVersion     :: Version
-    -- ^ The Avro version determines how a schema is converted to
-    -- Avro. The same schema compiled at the same Avro version should
-    -- always generate compatible Avro data.
-  , moduleName      :: Name.ModuleName
-    -- ^ The name of the module that this section belongs to.
-  } deriving (Show, Eq)
+    { -- | The version of the Theta language determines what language
+      -- features the schema can use and how those features work.
+      languageVersion :: Version
+    , -- | The Avro version determines how a schema is converted to
+      -- Avro. The same schema compiled at the same Avro version should
+      -- always generate compatible Avro data.
+      avroVersion :: Version
+    , -- | The name of the module that this section belongs to.
+      moduleName :: Name.ModuleName
+    }
+    deriving (Show, Eq)
 
 instance Arbitrary Metadata where
-  arbitrary = Metadata <$> arbitrary <*> arbitrary <*> arbitrary
+    arbitrary = Metadata <$> arbitrary <*> arbitrary <*> arbitrary
 
--- | A semantic version that's compliant with the semver spec.
---
--- This is just a wrapper over 'SemVer' that lets me add typeclass
--- instances.
+{- | A semantic version that's compliant with the semver spec.
+
+ This is just a wrapper over 'SemVer' that lets me add typeclass
+ instances.
+-}
 newtype Version = Version SemVer
-  deriving newtype (Show, Eq, Ord)
+    deriving newtype (Show, Eq, Ord)
 
 instance Arbitrary Version where
-  arbitrary = Version <$> semver
-    where semver = SemVer <$> arbitrary
-                          <*> arbitrary
-                          <*> arbitrary
-                          <*> pure []
-                          <*> pure []
+    arbitrary = Version <$> semver
+      where
+        semver =
+            SemVer <$> arbitrary
+                <*> arbitrary
+                <*> arbitrary
+                <*> pure []
+                <*> pure Nothing
 
--- | Render a 'Version' in a compact, human-readable format.
---
--- @
--- λ> show ("1.2.1" :: Version)
--- "SemVer {_svMajor = 1, _svMinor = 2, _svPatch = 1, _svPreRel = [], _svMeta = []}"
--- λ> pretty ("1.2.1" :: Version)
--- "1.2.1"
--- @
+{- | Render a 'Version' in a compact, human-readable format.
+
+ @
+ λ> show ("1.2.1" :: Version)
+ "SemVer {_svMajor = 1, _svMinor = 2, _svPatch = 1, _svPreRel = [], _svMeta = []}"
+ λ> pretty ("1.2.1" :: Version)
+ "1.2.1"
+ @
+-}
 instance Pretty Version where
-  pretty (Version semVer) = prettySemVer semVer
+    pretty (Version semVer) = prettySemVer semVer
 
--- | Turns a literal "1.2.0" into a 'Version'. Errors out if the
--- format is not compliant with semver.
+{- | Turns a literal "1.2.0" into a 'Version'. Errors out if the
+ format is not compliant with semver.
+-}
 instance IsString Version where
-  fromString str = case semver (Text.pack str) of
-    Left parseError -> error $ errorBundlePretty parseError
-    Right version   -> Version version
+    fromString str = case semver (Text.pack str) of
+        Left parseError -> error $ errorBundlePretty parseError
+        Right version -> Version version

--- a/theta/src/Theta/Target/Haskell.hs
+++ b/theta/src/Theta/Target/Haskell.hs
@@ -81,56 +81,7 @@ import           Data.Versions                   (SemVer(..), VUnit(..))
 import qualified GHC.Exts                        as Exts
 import           GHC.Generics                    (Generic)
 
-import Language.Haskell.TH as TH
-    ( newName,
-      mkName,
-      stringL,
-      integerL,
-      litP,
-      varP,
-      conP,
-      recP,
-      fieldPat,
-      match,
-      varE,
-      conE,
-      litE,
-      appTypeE,
-      infixE,
-      caseE,
-      doE,
-      listE,
-      recConE,
-      normalB,
-      bindS,
-      noBindS,
-      valD,
-      sigD,
-      noSourceUnpackedness,
-      noSourceStrictness,
-      sourceStrict,
-      normalC,
-      recC,
-      bang,
-      bangType,
-      varBangType,
-      conT,
-      Exp,
-      Q,
-      Type,
-      Dec,
-      BangTypeQ,
-      Name,
-      dataD,
-      derivClause,
-      newtypeD,
-      tySynD,
-      lookupValueName,
-      nameBase,
-      runIO,
-      Con,
-      DerivClause,
-      Stmt )
+import           Language.Haskell.TH             as TH
 import           Language.Haskell.TH.Syntax
 
 import           Theta.Error                     (Error)
@@ -146,7 +97,6 @@ import qualified Theta.Target.Avro.Values        as Theta
 
 import qualified Theta.Target.Haskell.Conversion as Conversion
 import           Theta.Target.Haskell.HasTheta   (HasTheta (..))
-import Data.Maybe (fromMaybe)
 
 -- * Generating Haskell types
 
@@ -302,7 +252,7 @@ generateMetadata Metadata { languageVersion, avroVersion, moduleName } =
                      , _svMinor  = $(litE $ integerL $ fromIntegral _svMinor)
                      , _svPatch  = $(litE $ integerL $ fromIntegral _svPatch)
                      , _svPreRel = $(listE $ units <$> _svPreRel)
-                     , _svMeta   = fromMaybe _svMeta
+                     , _svMeta   = $(meta _svMeta)
                      }
             |]
 
@@ -310,6 +260,10 @@ generateMetadata Metadata { languageVersion, avroVersion, moduleName } =
 
         unit (Digits word) = [e| Digits $(litE $ integerL $ fromIntegral word) |]
         unit (Str text)    = [e| Text $(litE $ stringL $ Text.unpack text) |]
+
+        meta = \case
+          Just text -> litE $ stringL $ Text.unpack text
+          Nothing   -> [e| Nothing |]
 
 -- ** Type Definitions
 

--- a/theta/src/Theta/Target/Haskell.hs
+++ b/theta/src/Theta/Target/Haskell.hs
@@ -81,7 +81,56 @@ import           Data.Versions                   (SemVer(..), VUnit(..))
 import qualified GHC.Exts                        as Exts
 import           GHC.Generics                    (Generic)
 
-import           Language.Haskell.TH             as TH
+import Language.Haskell.TH as TH
+    ( newName,
+      mkName,
+      stringL,
+      integerL,
+      litP,
+      varP,
+      conP,
+      recP,
+      fieldPat,
+      match,
+      varE,
+      conE,
+      litE,
+      appTypeE,
+      infixE,
+      caseE,
+      doE,
+      listE,
+      recConE,
+      normalB,
+      bindS,
+      noBindS,
+      valD,
+      sigD,
+      noSourceUnpackedness,
+      noSourceStrictness,
+      sourceStrict,
+      normalC,
+      recC,
+      bang,
+      bangType,
+      varBangType,
+      conT,
+      Exp,
+      Q,
+      Type,
+      Dec,
+      BangTypeQ,
+      Name,
+      dataD,
+      derivClause,
+      newtypeD,
+      tySynD,
+      lookupValueName,
+      nameBase,
+      runIO,
+      Con,
+      DerivClause,
+      Stmt )
 import           Language.Haskell.TH.Syntax
 
 import           Theta.Error                     (Error)
@@ -97,6 +146,7 @@ import qualified Theta.Target.Avro.Values        as Theta
 
 import qualified Theta.Target.Haskell.Conversion as Conversion
 import           Theta.Target.Haskell.HasTheta   (HasTheta (..))
+import Data.Maybe (fromMaybe)
 
 -- * Generating Haskell types
 
@@ -252,11 +302,11 @@ generateMetadata Metadata { languageVersion, avroVersion, moduleName } =
                      , _svMinor  = $(litE $ integerL $ fromIntegral _svMinor)
                      , _svPatch  = $(litE $ integerL $ fromIntegral _svPatch)
                      , _svPreRel = $(listE $ units <$> _svPreRel)
-                     , _svMeta   = $(listE $ units <$> _svMeta)
+                     , _svMeta   = fromMaybe _svMeta
                      }
             |]
 
-        units = listE . map unit
+        units = listE . toList . NonEmpty.map unit
 
         unit (Digits word) = [e| Digits $(litE $ integerL $ fromIntegral word) |]
         unit (Str text)    = [e| Text $(litE $ stringL $ Text.unpack text) |]

--- a/theta/theta.cabal
+++ b/theta/theta.cabal
@@ -32,7 +32,7 @@ common shared
                , aeson
                , aeson-pretty
                , aeson-qq
-               , avro >=0.5.2.0
+               , avro >=0.5.2.0 && <0.6
                , binary
                , bytestring
                , containers
@@ -51,7 +51,7 @@ common shared
                , time
                , unordered-containers
                , vector
-               , versions
+               , versions ==5.*
 
 flag isStatic
   manual: True


### PR DESCRIPTION
This required a couple of code changes (based on #8) as well as Nix and .cabal file updates. Should address the final comments in #3 as well.

Both the Haskell and the cross-language tests pass with Nix. The code should now build with LTS-18.21 on Stack, but I haven't tested that.