### PR TITLE
bump avro to 0.6.0.1

### DIFF
--- a/theta/stack.yaml
+++ b/theta/stack.yaml
@@ -1,1 +1,14 @@
 resolver: lts-18.21
+extra-deps:
+- git: git@github.com:haskell-works/avro.git
+  commit: ae14b8c24c190c110767e1279ef76dd342a42486
+- git: git@github.com:stackbuilders/stache.git
+  commit: f4e3b3f39efcdbb31588dd2a3f2fa73717094baf
+- aeson-2.0.3.0
+- OneTuple-0.3.1
+- attoparsec-0.14.4
+- hashable-1.4.0.2
+- semialign-1.2.0.1
+- text-short-0.1.5
+- time-compat-1.9.6.1
+

--- a/theta/test/Test/Theta/Parser.hs
+++ b/theta/test/Test/Theta/Parser.hs
@@ -471,7 +471,7 @@ assertFails = \case
 
 -- | Assert that the parser succeeds without specifying what the
 -- result should be.
-assertSucceeds :: (Stream s, ShowErrorComponent e)
+assertSucceeds :: (VisualStream s, TraversableStream s, Stream s, ShowErrorComponent e)
                => Either (ParseErrorBundle s e) b
                -> Assertion
 assertSucceeds = \case
@@ -484,7 +484,7 @@ assertSucceeds = \case
 
 -- | Check whether the given parse result has no errors and returns
 -- the expected value.
-(?=) :: (Show a, Eq a, Stream s, ShowErrorComponent e)
+(?=) :: (Show a, Eq a, VisualStream s, TraversableStream s, Stream s, ShowErrorComponent e)
      => Either (ParseErrorBundle s e) a
      -> a
      -> Assertion

--- a/theta/theta.cabal
+++ b/theta/theta.cabal
@@ -32,7 +32,7 @@ common shared
                , aeson
                , aeson-pretty
                , aeson-qq
-               , avro >=0.5.2.0 && <0.6
+               , avro >=0.6 && <0.7
                , binary
                , bytestring
                , containers
@@ -121,7 +121,7 @@ test-suite tests
 
                     , directory
                     , Diff
-                    , stache
+                    , stache >=2.3.1 && <3
 
                     , tasty
                     , tasty-golden


### PR DESCRIPTION
Hi, Tikhon.

Here's some version bumps so we can use the bugfixes in 0.6.0.1. Specifically one that has bitten us and we're very happy to say goodbye to.

I noticed some tests are failing due to files that are probably pulled in by `nix-shell`. I didn't make an effort to pull all the dependencies for these. Up to you. ;-)