### PR TITLE
Bump avro to 0.6.0.1

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -48,15 +48,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "nixpkgs-20.09-darwin",
+        "branch": "nixpkgs-21.11-darwin",
         "description": "Nix Packages collection",
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1c1f5649bb9c1b0d98637c8c365228f57126f361",
-        "sha256": "0f2nvdijyxfgl5kwyb4465pppd5vkhqxddx6v40k2s0z9jfhj0xl",
+        "rev": "46450f2f65f117459157e4ea90e39c6601e38109",
+        "sha256": "134j3ph5q874jrxy9l4bszq1zwpiwvmf916igav5a4bybc0a1i49",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/1c1f5649bb9c1b0d98637c8c365228f57126f361.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/46450f2f65f117459157e4ea90e39c6601e38109.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-mozilla": {

--- a/theta/default.nix
+++ b/theta/default.nix
@@ -3,7 +3,18 @@
 , pkgs ? import ../nix/nixpkgs.nix { inherit sources;}
 , compiler ? pkgs.haskell.packages."${compiler-version}"
 , source-overrides ? {
-  avro = "0.5.2.1";
+  aeson = "2.0.3.0";
+  aeson-pretty = "0.8.9";
+  attoparsec = "0.14.4";
+  avro = "0.6.0.1";
+  hashable = "1.4.0.2";
+  OneTuple = "0.3.1";
+  quickcheck-instances = "0.3.27";
+  semialign = "1.2.0.1";
+  stache = "2.3.1";
+  text-short = "0.1.5";
+  time-compat = "1.9.6.1";
+  unordered-containers = "0.2.16.0";
   versions = "5.0.2";
 }
 , werror ? true
@@ -53,8 +64,7 @@ compiler.developPackage {
 
   inherit source-overrides;
   overrides = new: old: {
-    language-rust = pkgs.haskell.lib.dontCheck
-      (new.callCabal2nix "language-rust" sources.language-rust {});
+    foldl = pkgs.haskell.lib.doJailbreak old.foldl;
   };
 
   # Don't try to build static executables on Darwin systems

--- a/theta/stack-shell.nix
+++ b/theta/stack-shell.nix
@@ -1,0 +1,14 @@
+{ ghc
+, pkgs ? import ../nix/nixpkgs.nix {}
+}:
+
+# On any system with Nix, you can build theta with Stack using:
+#
+# > stack --nix --nix-shell-file stack-shell.nix build
+
+pkgs.haskell.lib.buildStackProject {
+  inherit ghc;
+  name = "theta";
+
+  buildInputs = [ pkgs.zlib ];
+}

--- a/theta/stack.yaml
+++ b/theta/stack.yaml
@@ -1,1 +1,14 @@
 resolver: lts-18.21
+extra-deps:
+- git: git@github.com:haskell-works/avro.git
+  commit: ae14b8c24c190c110767e1279ef76dd342a42486
+- git: git@github.com:stackbuilders/stache.git
+  commit: f4e3b3f39efcdbb31588dd2a3f2fa73717094baf
+- aeson-2.0.3.0
+- OneTuple-0.3.1
+- attoparsec-0.14.4
+- hashable-1.4.0.2
+- semialign-1.2.0.1
+- text-short-0.1.5
+- time-compat-1.9.6.1
+

--- a/theta/test/Test/Theta/Import.hs
+++ b/theta/test/Test/Theta/Import.hs
@@ -163,19 +163,20 @@ test_findInPath :: TestTree
 test_findInPath = testGroup "findInPath"
   [ testCase "relative paths" $ do
       dir <- Paths.getDataDir
-      let loadPath = LoadPath [root1, root2]
+      withCurrentDirectory dir $ do
+        let loadPath = LoadPath [root1, root2]
 
-      let pathA = dir </> "test" </> "data" </> "root-1" </> "a.theta"
-      fileA <- Text.readFile pathA
-      Just (fileA', pathA') <- findInPath loadPath "a.theta"
-      assertEqualPath pathA' pathA
-      fileA' @?= fileA
+        let pathA = dir </> "test" </> "data" </> "root-1" </> "a.theta"
+        fileA <- Text.readFile pathA
+        Just (fileA', pathA') <- findInPath loadPath "a.theta"
+        assertEqualPath pathA' pathA
+        fileA' @?= fileA
 
-      let pathB = dir </> "test" </> "data" </> "root-2" </> "b.theta"
-      fileB <- Text.readFile pathB
-      Just (fileB', pathB') <- findInPath loadPath "b.theta"
-      assertEqualPath pathB' pathB
-      fileB' @?= fileB
+        let pathB = dir </> "test" </> "data" </> "root-2" </> "b.theta"
+        fileB <- Text.readFile pathB
+        Just (fileB', pathB') <- findInPath loadPath "b.theta"
+        assertEqualPath pathB' pathB
+        fileB' @?= fileB
 
   , testCase "absolute paths" $ do
       dir <- Paths.getDataDir

--- a/theta/test/Test/Theta/Parser.hs
+++ b/theta/test/Test/Theta/Parser.hs
@@ -471,7 +471,7 @@ assertFails = \case
 
 -- | Assert that the parser succeeds without specifying what the
 -- result should be.
-assertSucceeds :: (Stream s, ShowErrorComponent e)
+assertSucceeds :: (VisualStream s, TraversableStream s, Stream s, ShowErrorComponent e)
                => Either (ParseErrorBundle s e) b
                -> Assertion
 assertSucceeds = \case
@@ -484,7 +484,7 @@ assertSucceeds = \case
 
 -- | Check whether the given parse result has no errors and returns
 -- the expected value.
-(?=) :: (Show a, Eq a, Stream s, ShowErrorComponent e)
+(?=) :: (Show a, Eq a, VisualStream s, TraversableStream s, Stream s, ShowErrorComponent e)
      => Either (ParseErrorBundle s e) a
      -> a
      -> Assertion

--- a/theta/test/Test/Theta/Target/Rust.hs
+++ b/theta/test/Test/Theta/Target/Rust.hs
@@ -8,17 +8,13 @@
 
 module Test.Theta.Target.Rust where
 
-import           Control.Monad                 (when)
-
-import qualified Data.Algorithm.Diff           as Diff
-import qualified Data.Algorithm.DiffOutput     as Diff
-import qualified Data.Text                     as Text
 import qualified Data.Text.IO                  as Text
 
 import           System.FilePath               ((<.>), (</>))
 
 import qualified Theta.Metadata                as Theta
 import           Theta.Target.Haskell          (loadModule)
+import           Theta.Target.LanguageQuoter   ((?=))
 import           Theta.Target.Rust
 import           Theta.Target.Rust.QuasiQuoter (normalize)
 import qualified Theta.Types                   as Theta
@@ -45,42 +41,42 @@ tests = testGroup "Rust"
 test_toFile :: TestTree
 test_toFile = testCase "toFile" $ do
   expected <- loadRust "single_file"
-  toFile [theta'newtype, theta'recursive] ?= expected
+  toFile [theta'newtype, theta'recursive] ??= expected
 
 test_toModule :: TestTree
 test_toModule = testGroup "toModule"
   [ testCase "newtype.theta" $ do
       expected <- loadRust "newtype"
-      toModule theta'newtype ?= expected
+      toModule theta'newtype ??= expected
 
   , testCase "recursive.theta" $ do
       expected <- loadRust "recursive"
-      toModule theta'recursive ?= expected
+      toModule theta'recursive ??= expected
   ]
 
 test_toReference :: TestTree
 test_toReference = testGroup "toReference"
   [ testCase "primitive types" $ do
-      toReference Theta.bool'     ?= "bool"
-      toReference Theta.bytes'    ?= "Vec<u8>"
-      toReference Theta.int'      ?= "i32"
-      toReference Theta.long'     ?= "i64"
-      toReference Theta.float'    ?= "f32"
-      toReference Theta.double'   ?= "f64"
-      toReference Theta.date'     ?= "Date<Utc>"
-      toReference Theta.datetime' ?= "DateTime<Utc>"
+      toReference Theta.bool'     ??= "bool"
+      toReference Theta.bytes'    ??= "Vec<u8>"
+      toReference Theta.int'      ??= "i32"
+      toReference Theta.long'     ??= "i64"
+      toReference Theta.float'    ??= "f32"
+      toReference Theta.double'   ??= "f64"
+      toReference Theta.date'     ??= "Date<Utc>"
+      toReference Theta.datetime' ??= "DateTime<Utc>"
 
   , testCase "containers" $ do
-      toReference (Theta.array' Theta.int')       ?= "Vec<i32>"
-      toReference (Theta.array' Theta.string')    ?= "Vec<String>"
-      toReference (Theta.map' Theta.int')         ?= "HashMap<String, i32>"
-      toReference (Theta.map' Theta.string')      ?= "HashMap<String, String>"
-      toReference (Theta.optional' Theta.int')    ?= "Option<i32>"
-      toReference (Theta.optional' Theta.string') ?= "Option<String>"
+      toReference (Theta.array' Theta.int')       ??= "Vec<i32>"
+      toReference (Theta.array' Theta.string')    ??= "Vec<String>"
+      toReference (Theta.map' Theta.int')         ??= "HashMap<String, i32>"
+      toReference (Theta.map' Theta.string')      ??= "HashMap<String, String>"
+      toReference (Theta.optional' Theta.int')    ??= "Option<i32>"
+      toReference (Theta.optional' Theta.string') ??= "Option<String>"
 
-      toReference (Theta.array' $ Theta.map' Theta.int')     ?= "Vec<HashMap<String, i32>>"
-      toReference (Theta.map' $ Theta.array' Theta.int')     ?= "HashMap<String, Vec<i32>>"
-      toReference (Theta.array'$ Theta.optional' Theta.int') ?= "Vec<Option<i32>>"
+      toReference (Theta.array' $ Theta.map' Theta.int')     ??= "Vec<HashMap<String, i32>>"
+      toReference (Theta.map' $ Theta.array' Theta.int')     ??= "HashMap<String, Vec<i32>>"
+      toReference (Theta.array'$ Theta.optional' Theta.int') ??= "Vec<Option<i32>>"
 
   , testCase "named types" $ do
       let reference = wrap $ Theta.Reference' "base.FooReference"
@@ -89,17 +85,17 @@ test_toReference = testGroup "toReference"
             [ Theta.Case "base.Foo" Nothing [] ]
           newtype_  = wrap $ Theta.Newtype' "base.FooNewtype" record
 
-      toReference reference ?= "base::FooReference"
-      toReference record    ?= "base::FooRecord"
-      toReference variant   ?= "base::FooVariant"
-      toReference newtype_  ?= "base::FooNewtype"
+      toReference reference ??= "base::FooReference"
+      toReference record    ??= "base::FooRecord"
+      toReference variant   ??= "base::FooVariant"
+      toReference newtype_  ??= "base::FooNewtype"
   ]
   where wrap = Theta.withModule' Theta.baseModule
 
 test_toRecord :: TestTree
 test_toRecord = testGroup "toRecord"
   [ testCase "empty record" $ do
-      toRecord "foo.Empty" [] ?=
+      toRecord "foo.Empty" [] ??=
         [rust|
           #[derive(Clone, Debug, PartialEq)]
           pub struct Empty {
@@ -125,7 +121,7 @@ test_toRecord = testGroup "toRecord"
           input = Theta.Field "input" Nothing Theta.string'
           -- fields named "input" need special handling
 
-      toRecord "foo.OneField" [foo] ?=
+      toRecord "foo.OneField" [foo] ??=
         [rust|
           #[derive(Clone, Debug, PartialEq)]
           pub struct OneField {
@@ -149,7 +145,7 @@ test_toRecord = testGroup "toRecord"
         |]
 
 
-      toRecord "foo.TwoFields" [foo, input] ?=
+      toRecord "foo.TwoFields" [foo, input] ??=
         [rust|
           #[derive(Clone, Debug, PartialEq)]
           pub struct TwoFields {
@@ -178,7 +174,7 @@ test_toRecord = testGroup "toRecord"
 
   , testCase "references" $ do
       let foo = Theta.Field "foo" Nothing (reference "foo.Foo")
-      toRecord "foo.Foo" [foo] ?=
+      toRecord "foo.Foo" [foo] ??=
         [rust|
           #[derive(Clone, Debug, PartialEq)]
           pub struct Foo {
@@ -202,7 +198,7 @@ test_toRecord = testGroup "toRecord"
         |]
 
 
-      toRecord "foo.Bar" [foo] ?=
+      toRecord "foo.Bar" [foo] ??=
         [rust|
           #[derive(Clone, Debug, PartialEq)]
           pub struct Bar {
@@ -231,7 +227,7 @@ test_toVariant :: TestTree
 test_toVariant = testGroup "toVariant"
   [ testCase "single case" $ do
       let cases = [Theta.Case "foo.Case" Nothing [Theta.Field "foo" Nothing Theta.int']]
-      toVariant "foo.Variant" cases ?=
+      toVariant "foo.Variant" cases ??=
         [rust|
           #[derive(Clone, Debug, PartialEq)]
           pub enum Variant {
@@ -273,7 +269,7 @@ test_toVariant = testGroup "toVariant"
                                                  , Theta.Field "input" Nothing Theta.string'
                                                  ]
                   ]
-      toVariant "foo.Variant" cases ?=
+      toVariant "foo.Variant" cases ??=
         [rust|
           #[derive(Clone, Debug, PartialEq)]
           pub enum Variant {
@@ -327,7 +323,7 @@ test_toVariant = testGroup "toVariant"
 test_toNewtype :: TestTree
 test_toNewtype = testGroup "toNewtype"
   [ testCase "primitive" $ do
-      toNewtype "foo.Foo" Theta.int' ?=
+      toNewtype "foo.Foo" Theta.int' ??=
        [rust|
          #[derive(Copy, Clone, Debug, PartialEq)]
          pub struct Foo(pub i32);
@@ -349,7 +345,7 @@ test_toNewtype = testGroup "toNewtype"
        |]
 
   , testCase "reference" $ do
-      toNewtype "foo.Foo" (reference "foo.Bar") ?=
+      toNewtype "foo.Foo" (reference "foo.Bar") ??=
        [rust|
          #[derive(Copy, Clone, Debug, PartialEq)]
          pub struct Foo(pub foo::Bar);
@@ -371,7 +367,7 @@ test_toNewtype = testGroup "toNewtype"
        |]
 
   , testCase "container" $ do
-     toNewtype "foo.Foo" (Theta.array' Theta.double') ?=
+     toNewtype "foo.Foo" (Theta.array' Theta.double') ??=
        [rust|
          #[derive(Clone, Debug, PartialEq)]
          pub struct Foo(pub Vec<f64>);
@@ -401,15 +397,15 @@ test_toNewtype = testGroup "toNewtype"
 test_alias :: TestTree
 test_alias = testGroup "alias"
   [ testCase "primitive" $ do
-      toDefinition (Theta.Definition "foo.Foo" Nothing Theta.int') ?=
+      toDefinition (Theta.Definition "foo.Foo" Nothing Theta.int') ??=
         "pub type Foo = i32;"
 
   , testCase "reference" $ do
-      toDefinition (Theta.Definition "foo.Foo" Nothing (reference "foo.Bar")) ?=
+      toDefinition (Theta.Definition "foo.Foo" Nothing (reference "foo.Bar")) ??=
         "pub type Foo = foo::Bar;"
 
   , testCase "container" $ do
-     toDefinition (Theta.Definition "foo.Foo" Nothing (Theta.array' Theta.double')) ?=
+     toDefinition (Theta.Definition "foo.Foo" Nothing (Theta.array' Theta.double')) ??=
        "pub type Foo = Vec<f64>;"
   ]
   where reference = Theta.withModule' fooModule . Theta.Reference'
@@ -440,13 +436,5 @@ loadRust name = do
 -- of the *normalized* versions of the code. The normalized version is
 -- a bit less readable, but comparing them makes debugging tests a lot
 -- easier!
-(?=) :: Rust -> Rust -> Assertion
-a ?= b = do
-  let Rust a' = normalize a
-      Rust b' = normalize b
-  when (a' /= b') $ assertFailure $
-    Diff.ppDiff $ toString <$> Diff.getGroupedDiff (Text.lines a') (Text.lines b')
-  where toString :: Diff.Diff [Text.Text] -> Diff.Diff [String]
-        toString (Diff.First a)  = Diff.First  (Text.unpack <$> a)
-        toString (Diff.Second b) = Diff.Second (Text.unpack <$> b)
-        toString (Diff.Both a b) = Diff.Both   (Text.unpack <$> a) (Text.unpack <$> b)
+(??=) :: Rust -> Rust -> Assertion
+a ??= b = normalize a ?= normalize b

--- a/theta/test/data/python/bar_reference.mustache
+++ b/theta/test/data/python/bar_reference.mustache
@@ -1,6 +1,6 @@
 @dataclass
 class Bar:
-    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta 1.0.0.0\\nType hash: f1f8d49e53501056214b7d466b09e73c","fields":[{"aliases":[],"name":"foo","type":{"aliases":[],"fields":[{"aliases":[],"name":"foo","type":"Foo"}],"name":"Foo","type":"record"}}],"name":"test.Bar","type":"record"}''')
+    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta {{version}}\\nType hash: f1f8d49e53501056214b7d466b09e73c","fields":[{"aliases":[],"name":"foo","type":{"aliases":[],"fields":[{"aliases":[],"name":"foo","type":"Foo"}],"name":"Foo","type":"record"}}],"name":"test.Bar","type":"record"}''')
 
     foo: 'Foo'
 

--- a/theta/test/data/python/bar_reference.mustache
+++ b/theta/test/data/python/bar_reference.mustache
@@ -1,6 +1,6 @@
 @dataclass
 class Bar:
-    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"doc":"Generated with Theta {{version}}\\nType hash: f1f8d49e53501056214b7d466b09e73c","aliases":[],"name":"test.Bar","type":"record","fields":[{"aliases":[],"name":"foo","type":{"aliases":[],"name":"Foo","type":"record","fields":[{"aliases":[],"name":"foo","type":"Foo"}]}}]}''')
+    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta 1.0.0.0\\nType hash: f1f8d49e53501056214b7d466b09e73c","fields":[{"aliases":[],"name":"foo","type":{"aliases":[],"fields":[{"aliases":[],"name":"foo","type":"Foo"}],"name":"Foo","type":"record"}}],"name":"test.Bar","type":"record"}''')
 
     foo: 'Foo'
 

--- a/theta/test/data/python/empty_record.mustache
+++ b/theta/test/data/python/empty_record.mustache
@@ -1,6 +1,6 @@
 @dataclass
 class Empty:
-    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"doc":"Generated with Theta {{version}}\\nType hash: 5d6c7cc16624e5f0ef7add5940e16636","aliases":[],"name":"test.Empty","type":"record","fields":[]}''')
+    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta 1.0.0.0\\nType hash: 5d6c7cc16624e5f0ef7add5940e16636","fields":[],"name":"test.Empty","type":"record"}''')
 
 
 

--- a/theta/test/data/python/empty_record.mustache
+++ b/theta/test/data/python/empty_record.mustache
@@ -1,6 +1,6 @@
 @dataclass
 class Empty:
-    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta 1.0.0.0\\nType hash: 5d6c7cc16624e5f0ef7add5940e16636","fields":[],"name":"test.Empty","type":"record"}''')
+    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta {{version}}\\nType hash: 5d6c7cc16624e5f0ef7add5940e16636","fields":[],"name":"test.Empty","type":"record"}''')
 
 
 

--- a/theta/test/data/python/foo_reference.mustache
+++ b/theta/test/data/python/foo_reference.mustache
@@ -1,6 +1,6 @@
 @dataclass
 class Foo:
-    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta 1.0.0.0\\nType hash: 04ca89441b4b70bfd004931441693fcb","fields":[{"aliases":[],"name":"foo","type":"Foo"}],"name":"test.Foo","type":"record"}''')
+    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta {{version}}\\nType hash: 04ca89441b4b70bfd004931441693fcb","fields":[{"aliases":[],"name":"foo","type":"Foo"}],"name":"test.Foo","type":"record"}''')
 
     foo: 'Foo'
 

--- a/theta/test/data/python/foo_reference.mustache
+++ b/theta/test/data/python/foo_reference.mustache
@@ -1,6 +1,6 @@
 @dataclass
 class Foo:
-    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"doc":"Generated with Theta {{version}}\\nType hash: 04ca89441b4b70bfd004931441693fcb","aliases":[],"name":"test.Foo","type":"record","fields":[{"aliases":[],"name":"foo","type":"Foo"}]}''')
+    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta 1.0.0.0\\nType hash: 04ca89441b4b70bfd004931441693fcb","fields":[{"aliases":[],"name":"foo","type":"Foo"}],"name":"test.Foo","type":"record"}''')
 
     foo: 'Foo'
 

--- a/theta/test/data/python/importing_reference.mustache
+++ b/theta/test/data/python/importing_reference.mustache
@@ -1,6 +1,6 @@
 @dataclass
 class Foo:
-    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"doc":"Generated with Theta {{version}}\\nType hash: 59729a8cb95b8e1b6afeceef2a983cf4","aliases":[],"name":"test.Foo","type":"record","fields":[{"aliases":[],"name":"importing","type":{"aliases":[],"name":"imported.Foo","type":"record","fields":[]}}]}''')
+    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta 1.0.0.0\\nType hash: 59729a8cb95b8e1b6afeceef2a983cf4","fields":[{"aliases":[],"name":"importing","type":{"aliases":[],"fields":[],"name":"imported.Foo","type":"record"}}],"name":"test.Foo","type":"record"}''')
 
     importing: 'imported.Foo'
 

--- a/theta/test/data/python/importing_reference.mustache
+++ b/theta/test/data/python/importing_reference.mustache
@@ -1,6 +1,6 @@
 @dataclass
 class Foo:
-    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta 1.0.0.0\\nType hash: 59729a8cb95b8e1b6afeceef2a983cf4","fields":[{"aliases":[],"name":"importing","type":{"aliases":[],"fields":[],"name":"imported.Foo","type":"record"}}],"name":"test.Foo","type":"record"}''')
+    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta {{version}}\\nType hash: 59729a8cb95b8e1b6afeceef2a983cf4","fields":[{"aliases":[],"name":"importing","type":{"aliases":[],"fields":[],"name":"imported.Foo","type":"record"}}],"name":"test.Foo","type":"record"}''')
 
     importing: 'imported.Foo'
 

--- a/theta/test/data/python/newtype.mustache
+++ b/theta/test/data/python/newtype.mustache
@@ -12,7 +12,7 @@ Newtype = 'int'
 
 @dataclass
 class NewtypeRecord:
-    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta 1.0.0.0\\nType hash: 38cea8f7c32e301f5430960b45092ebf","fields":[{"aliases":[],"name":"foo","type":"int"}],"name":"newtype.NewtypeRecord","type":"record"}''')
+    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta {{version}}\\nType hash: 38cea8f7c32e301f5430960b45092ebf","fields":[{"aliases":[],"name":"foo","type":"int"}],"name":"newtype.NewtypeRecord","type":"record"}''')
 
     foo: 'Newtype'
 

--- a/theta/test/data/python/newtype.mustache
+++ b/theta/test/data/python/newtype.mustache
@@ -12,7 +12,7 @@ Newtype = 'int'
 
 @dataclass
 class NewtypeRecord:
-    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"doc":"Generated with Theta {{version}}\\nType hash: 38cea8f7c32e301f5430960b45092ebf","aliases":[],"name":"newtype.NewtypeRecord","type":"record","fields":[{"aliases":[],"name":"foo","type":"int"}]}''')
+    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta 1.0.0.0\\nType hash: 38cea8f7c32e301f5430960b45092ebf","fields":[{"aliases":[],"name":"foo","type":"int"}],"name":"newtype.NewtypeRecord","type":"record"}''')
 
     foo: 'Newtype'
 

--- a/theta/test/data/python/one_case.mustache
+++ b/theta/test/data/python/one_case.mustache
@@ -1,5 +1,5 @@
 class Variant(ABC):
-    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta 1.0.0.0\\nType hash: a5c4c2ebac1fd93bd80d4ff0d02bc224","fields":[{"aliases":[],"name":"constructor","type":[{"aliases":[],"fields":[{"aliases":[],"name":"foo","type":"int"}],"name":"Case","type":"record"}]}],"name":"test.Variant","type":"record"}''')
+    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta {{version}}\\nType hash: a5c4c2ebac1fd93bd80d4ff0d02bc224","fields":[{"aliases":[],"name":"constructor","type":[{"aliases":[],"fields":[{"aliases":[],"name":"foo","type":"int"}],"name":"Case","type":"record"}]}],"name":"test.Variant","type":"record"}''')
 
     @staticmethod
     def decode_avro(decoder: avro.Decoder):

--- a/theta/test/data/python/one_case.mustache
+++ b/theta/test/data/python/one_case.mustache
@@ -1,5 +1,5 @@
 class Variant(ABC):
-    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"doc":"Generated with Theta {{version}}\\nType hash: a5c4c2ebac1fd93bd80d4ff0d02bc224","aliases":[],"name":"test.Variant","type":"record","fields":[{"aliases":[],"name":"constructor","type":[{"aliases":[],"name":"Case","type":"record","fields":[{"aliases":[],"name":"foo","type":"int"}]}]}]}''')
+    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta 1.0.0.0\\nType hash: a5c4c2ebac1fd93bd80d4ff0d02bc224","fields":[{"aliases":[],"name":"constructor","type":[{"aliases":[],"fields":[{"aliases":[],"name":"foo","type":"int"}],"name":"Case","type":"record"}]}],"name":"test.Variant","type":"record"}''')
 
     @staticmethod
     def decode_avro(decoder: avro.Decoder):

--- a/theta/test/data/python/one_case_importing.mustache
+++ b/theta/test/data/python/one_case_importing.mustache
@@ -1,5 +1,5 @@
 class Variant(ABC):
-    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"doc":"Generated with Theta {{version}}\\nType hash: 0f3c222bbed476de54b4617234f058b5","aliases":[],"name":"test.Variant","type":"record","fields":[{"aliases":[],"name":"constructor","type":[{"aliases":[],"name":"Case","type":"record","fields":[{"aliases":[],"name":"importing","type":{"aliases":[],"name":"imported.Foo","type":"record","fields":[]}}]}]}]}''')
+    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta 1.0.0.0\\nType hash: 0f3c222bbed476de54b4617234f058b5","fields":[{"aliases":[],"name":"constructor","type":[{"aliases":[],"fields":[{"aliases":[],"name":"importing","type":{"aliases":[],"fields":[],"name":"imported.Foo","type":"record"}}],"name":"Case","type":"record"}]}],"name":"test.Variant","type":"record"}''')
 
     @staticmethod
     def decode_avro(decoder: avro.Decoder):

--- a/theta/test/data/python/one_case_importing.mustache
+++ b/theta/test/data/python/one_case_importing.mustache
@@ -1,5 +1,5 @@
 class Variant(ABC):
-    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta 1.0.0.0\\nType hash: 0f3c222bbed476de54b4617234f058b5","fields":[{"aliases":[],"name":"constructor","type":[{"aliases":[],"fields":[{"aliases":[],"name":"importing","type":{"aliases":[],"fields":[],"name":"imported.Foo","type":"record"}}],"name":"Case","type":"record"}]}],"name":"test.Variant","type":"record"}''')
+    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta {{version}}\\nType hash: 0f3c222bbed476de54b4617234f058b5","fields":[{"aliases":[],"name":"constructor","type":[{"aliases":[],"fields":[{"aliases":[],"name":"importing","type":{"aliases":[],"fields":[],"name":"imported.Foo","type":"record"}}],"name":"Case","type":"record"}]}],"name":"test.Variant","type":"record"}''')
 
     @staticmethod
     def decode_avro(decoder: avro.Decoder):

--- a/theta/test/data/python/one_field.mustache
+++ b/theta/test/data/python/one_field.mustache
@@ -1,6 +1,6 @@
 @dataclass
 class OneField:
-    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta 1.0.0.0\\nType hash: eda14f6cd3eb32f2798dc03dbb9f4a4d","fields":[{"aliases":[],"name":"foo","type":"int"}],"name":"test.OneField","type":"record"}''')
+    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta {{version}}\\nType hash: eda14f6cd3eb32f2798dc03dbb9f4a4d","fields":[{"aliases":[],"name":"foo","type":"int"}],"name":"test.OneField","type":"record"}''')
 
     foo: 'int'
 

--- a/theta/test/data/python/one_field.mustache
+++ b/theta/test/data/python/one_field.mustache
@@ -1,6 +1,6 @@
 @dataclass
 class OneField:
-    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"doc":"Generated with Theta {{version}}\\nType hash: eda14f6cd3eb32f2798dc03dbb9f4a4d","aliases":[],"name":"test.OneField","type":"record","fields":[{"aliases":[],"name":"foo","type":"int"}]}''')
+    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta 1.0.0.0\\nType hash: eda14f6cd3eb32f2798dc03dbb9f4a4d","fields":[{"aliases":[],"name":"foo","type":"int"}],"name":"test.OneField","type":"record"}''')
 
     foo: 'int'
 

--- a/theta/test/data/python/two_cases.mustache
+++ b/theta/test/data/python/two_cases.mustache
@@ -1,5 +1,5 @@
 class Variant(ABC):
-    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"doc":"Generated with Theta {{version}}\\nType hash: f9f5fa87870bc4fe62b567186a1c485d","aliases":[],"name":"test.Variant","type":"record","fields":[{"aliases":[],"name":"constructor","type":[{"aliases":[],"name":"One","type":"record","fields":[{"aliases":[],"name":"foo","type":"int"}]},{"aliases":[],"name":"Two","type":"record","fields":[{"aliases":[],"name":"foo","type":"int"},{"aliases":[],"name":"bar","type":"string"}]}]}]}''')
+    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta 1.0.0.0\\nType hash: f9f5fa87870bc4fe62b567186a1c485d","fields":[{"aliases":[],"name":"constructor","type":[{"aliases":[],"fields":[{"aliases":[],"name":"foo","type":"int"}],"name":"One","type":"record"},{"aliases":[],"fields":[{"aliases":[],"name":"foo","type":"int"},{"aliases":[],"name":"bar","type":"string"}],"name":"Two","type":"record"}]}],"name":"test.Variant","type":"record"}''')
 
     @staticmethod
     def decode_avro(decoder: avro.Decoder):

--- a/theta/test/data/python/two_cases.mustache
+++ b/theta/test/data/python/two_cases.mustache
@@ -1,5 +1,5 @@
 class Variant(ABC):
-    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta 1.0.0.0\\nType hash: f9f5fa87870bc4fe62b567186a1c485d","fields":[{"aliases":[],"name":"constructor","type":[{"aliases":[],"fields":[{"aliases":[],"name":"foo","type":"int"}],"name":"One","type":"record"},{"aliases":[],"fields":[{"aliases":[],"name":"foo","type":"int"},{"aliases":[],"name":"bar","type":"string"}],"name":"Two","type":"record"}]}],"name":"test.Variant","type":"record"}''')
+    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta {{version}}\\nType hash: f9f5fa87870bc4fe62b567186a1c485d","fields":[{"aliases":[],"name":"constructor","type":[{"aliases":[],"fields":[{"aliases":[],"name":"foo","type":"int"}],"name":"One","type":"record"},{"aliases":[],"fields":[{"aliases":[],"name":"foo","type":"int"},{"aliases":[],"name":"bar","type":"string"}],"name":"Two","type":"record"}]}],"name":"test.Variant","type":"record"}''')
 
     @staticmethod
     def decode_avro(decoder: avro.Decoder):

--- a/theta/test/data/python/two_fields.mustache
+++ b/theta/test/data/python/two_fields.mustache
@@ -1,6 +1,6 @@
 @dataclass
 class TwoFields:
-    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta 1.0.0.0\\nType hash: 24395e1c611e39dc7b5aa9f87ec2292c","fields":[{"aliases":[],"name":"foo","type":"int"},{"aliases":[],"name":"bar","type":"string"}],"name":"test.TwoFields","type":"record"}''')
+    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta {{version}}\\nType hash: 24395e1c611e39dc7b5aa9f87ec2292c","fields":[{"aliases":[],"name":"foo","type":"int"},{"aliases":[],"name":"bar","type":"string"}],"name":"test.TwoFields","type":"record"}''')
 
     foo: 'int'
     bar: 'str'

--- a/theta/test/data/python/two_fields.mustache
+++ b/theta/test/data/python/two_fields.mustache
@@ -1,6 +1,6 @@
 @dataclass
 class TwoFields:
-    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"doc":"Generated with Theta {{version}}\\nType hash: 24395e1c611e39dc7b5aa9f87ec2292c","aliases":[],"name":"test.TwoFields","type":"record","fields":[{"aliases":[],"name":"foo","type":"int"},{"aliases":[],"name":"bar","type":"string"}]}''')
+    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta 1.0.0.0\\nType hash: 24395e1c611e39dc7b5aa9f87ec2292c","fields":[{"aliases":[],"name":"foo","type":"int"},{"aliases":[],"name":"bar","type":"string"}],"name":"test.TwoFields","type":"record"}''')
 
     foo: 'int'
     bar: 'str'

--- a/theta/theta.cabal
+++ b/theta/theta.cabal
@@ -30,15 +30,17 @@ common shared
   build-depends: base
 
                , aeson
-               , aeson-pretty
+               , aeson-pretty >=0.8.9 && <0.9
                , aeson-qq
                , avro >=0.6 && <0.7
                , binary
                , bytestring
                , containers
                , deepseq
+               , Diff
                , filepath
                , hashable
+               , indexed-traversable
                , megaparsec
                , mtl
                , prettyprinter
@@ -48,6 +50,7 @@ common shared
                , template-haskell
                , text
                , tagged
+               , tasty-hunit
                , time
                , unordered-containers
                , vector
@@ -120,7 +123,6 @@ test-suite tests
   build-depends:      theta
 
                     , directory
-                    , Diff
                     , stache >=2.3.1 && <3
 
                     , tasty

--- a/theta/theta.cabal
+++ b/theta/theta.cabal
@@ -32,7 +32,7 @@ common shared
                , aeson
                , aeson-pretty
                , aeson-qq
-               , avro >=0.5.2.0 && <0.6
+               , avro >=0.6 && <0.7
                , binary
                , bytestring
                , containers
@@ -121,7 +121,7 @@ test-suite tests
 
                     , directory
                     , Diff
-                    , stache
+                    , stache >=2.3.1 && <3
 
                     , tasty
                     , tasty-golden

--- a/theta/theta.cabal
+++ b/theta/theta.cabal
@@ -1,18 +1,20 @@
 cabal-version:  2.2
 name:           theta
 version:        1.0.0.0
+synopsis:       Share algebraic data types across different languages with Avro.
+description:    Use algebraic data types to define data formats that work across different languages. Theta is an interface description language (IDL) designed around Avro.
 license:        Apache-2.0
+category:       Language
 build-type:     Simple
-extra-source-files:
+maintainer:     Tikhon Jelvis <tikhon@jelv.is>
+data-files:
   test/data/containers/*.avro
   test/data/modules/*.theta
   test/data/transitive/*.theta
-  test/data/theta-root-1/*.theta
-  test/data/theta-root-2/*.theta
+  test/data/root-1/*.theta
+  test/data/root-2/*.theta
 
-  test/data/kotlin/*.kt
   test/data/python/*.mustache
-  test/data/python/*.py
   test/data/rust/*.rs
 
 common shared
@@ -27,7 +29,7 @@ common shared
 
                -- turn off warning from C preprocess on macOS
                -optP-Wno-nonportable-include-path
-  build-depends: base
+  build-depends: base ==4.13.*
 
                , aeson
                , aeson-pretty >=0.8.9 && <0.9
@@ -93,6 +95,7 @@ library
                     , Theta.Target.Rust
                     , Theta.Target.Rust.QuasiQuoter
   other-modules:      Paths_theta
+  autogen-modules:    Paths_theta
 
 test-suite tests
   import:             shared
@@ -120,6 +123,9 @@ test-suite tests
 
                     , Paths_theta
 
+  autogen-modules:    Paths_theta
+
+
   build-depends:      theta
 
                     , directory
@@ -139,14 +145,16 @@ executable theta
                     , optparse-applicative
 
   main-is:            Theta.hs
-  other-modules:      Paths_theta
-
-                    , Apps.Avro
+  other-modules:      Apps.Avro
                     , Apps.Hash
                     , Apps.Kotlin
                     , Apps.Python
                     , Apps.Rust
                     , Apps.Subcommand
+
+                    , Paths_theta
+  autogen-modules:    Paths_theta
+
   if flag(isStatic)
     ghc-options: -optl=-static -optl=-pthread -static
     ld-options: -static

--- a/theta/theta.cabal
+++ b/theta/theta.cabal
@@ -29,7 +29,7 @@ common shared
 
                -- turn off warning from C preprocess on macOS
                -optP-Wno-nonportable-include-path
-  build-depends: base ==4.13.*
+  build-depends: base >=4.13 && <4.15
 
                , aeson
                , aeson-pretty >=0.8.9 && <0.9


### PR DESCRIPTION
Bumped `avro` to 0.6.0.1, based on the changes suggested in #15

This required bumping a number of other packages in `default.nix` as well as updating a bunch of the Python test files. To make fixing the Python tests easier, I generalized the human-readable diff code from the Rust tests to work for any of the `LanguageQuoter`-based tests.