### PR TITLE
Fixed comment parsing in the metadata section

### DIFF
--- a/theta/src/Theta/Parser.hs
+++ b/theta/src/Theta/Parser.hs
@@ -82,6 +82,7 @@ data MetadataEntry = LanguageVersion Version
 -- @
 metadataSection :: Name.ModuleName -> Parsec Void Text Metadata
 metadataSection moduleName = do
+  void whitespace
   first    <- languageVersion <|> avroVersion
   metadata <- case first of
     LanguageVersion language -> do
@@ -97,7 +98,7 @@ metadataSection moduleName = do
         languageVersion =
           symbol "language-version" *> symbol ":" *> (LanguageVersion <$> version)
 
-        version = Version <$> semver'
+        version = (Version <$> semver') <* whitespace
 
         symbol     = L.symbol whitespace
         whitespace =


### PR DESCRIPTION
Previously, comments were not always handled correctly in the metadata section on top of a Theta file. Now they are.

```
// Comments on the very top
language-version: 1.0.0 // After each line
/* In between */
avro-version: /*even here*/ 1.0.0
// ...
---
```

In principle this is a language change that should be reflected in the `language-version` for a module, but this is hard to do since it affects the metadata parser... which is what figures out the `language-version` for a module—dealing with this is needlessly complex for a small backwards-compatible change.