### PR TITLE
Set up GitHub Actions for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,14 +24,18 @@ jobs:
       - name: Build Theta
         run: nix-build theta
 
-      - name: Stack Test
-        run: ci/stack-test ./theta
-
       - name: Cache Stack Dependencies
         uses: actions/cache@v2
         with:
-          path: ~/.stack
-          key: ${{ runner.os }}-store-${{ hashFiles('theta/stack.yaml.lock') }}-${{ hashFiles('theta/stack.yaml.lock') }}
-            
+          path: |
+            ~/.stack
+            .stack-work
+          key: ${{ runner.os }}-stack-${{ hashFiles('theta/stack.yaml.lock', 'theta/theta.cabal') }}
+          restore-keys: |
+            ${{ runner.os }}-stack
+
+      - name: Stack Test
+        run: ci/stack-test ./theta
+
       - name: Cross-Language Tests
         run: nix-build test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,4 +28,7 @@ jobs:
         run: nix-build test
 
       - name: Stack test
-        run: cd theta && stack --nix --nix-shell-file stack-shell.nix test
+        run: |
+          nix-shell
+          cd theta
+          stack --nix --nix-shell-file stack-shell.nix test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v12
+
+      - name: Cachix
+        uses: cachix/cachix-action@v10
+        with:
+          name: theta-idl
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+      - name: build haskell
+        run: nix-build theta
+
+      - name: cross-language tests
+        run: nix-build test
+
+      - name: Stack test
+        run: cd theta && stack --nix --nix-shell-file stack-shell.nix test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,14 +21,17 @@ jobs:
           name: theta-idl
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
-      - name: build haskell
+      - name: Build Theta
         run: nix-build theta
 
-      - name: cross-language tests
-        run: nix-build test
+      - name: Stack Test
+        run: ci/stack-test ./theta
 
-      - name: Stack test
-        run: |
-          nix-shell
-          cd theta
-          stack --nix --nix-shell-file stack-shell.nix test
+      - name: Cache Stack Dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.stack
+          key: ${{ runner.os }}-store-${{ hashFiles('theta/stack.yaml.lock') }}-${{ hashFiles('theta/stack.yaml.lock') }}
+            
+      - name: Cross-Language Tests
+        run: nix-build test

--- a/ci/stack-test
+++ b/ci/stack-test
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Run Stack test on the given directory, setting up the Nix
+# integration with Nixpkgs controlled by sources.nix
+
+# Should be run from top-level directory in repo:
+#
+# ci/stack-test theta
+
+expr='"nixpkgs=${(import nix/sources.nix).nixpkgs}"'
+nix_path="$(eval echo "$(nix-instantiate --eval -E "$expr")")"
+
+cd $1
+stack --nix \
+      --nix-shell-file stack-shell.nix \
+      --nix-path="$nix_path" \
+      test

--- a/shell.nix
+++ b/shell.nix
@@ -4,6 +4,7 @@
 }:
 
 let
+  sources = import nix/sources.nix;
 
   nightly-channel = pkgs.rustChannelOf {
     channel = "nightly";
@@ -38,5 +39,9 @@ pkgs.lib.overrideDerivation theta.env (old: {
   # https://github.com/target/lorri/issues/383
   shellHook = ''
     unset SOURCE_DATE_EPOCH
+
+    # Make sure Stack and other Nix commands use right
+    # base version of Nixpkgs
+    export NIX_PATH="nixpkgs=${sources.nixpkgs}"
   '';
 })

--- a/test/default.nix
+++ b/test/default.nix
@@ -1,6 +1,5 @@
 { pkgs ? import ../nix/nixpkgs.nix {}
-, theta ? import ../theta { inherit werror; }
-, werror ? false
+, theta ? import ../theta {}
 }:
 
 {

--- a/theta/default.nix
+++ b/theta/default.nix
@@ -50,6 +50,14 @@ let
   expose-cabal = p:
     pkgs.haskell.lib.addBuildTool p compiler.cabal-install;
 
+  excluded = [
+    "dist"
+    "dist-newstyle"
+    "stack.yaml"
+    ".stack-work"
+    "stack.yaml.lock"
+    "stack-shell.nix"
+  ];
 in
 compiler.developPackage {
   name = "theta";
@@ -57,7 +65,7 @@ compiler.developPackage {
     {
       src = ./.;
       filter = path: type:
-           !(baseNameOf (toString path) == "dist-newstyle")
+           !(pkgs.lib.elem (baseNameOf (toString path)) excluded)
         && !pkgs.lib.hasPrefix ".ghc.environment." (baseNameOf (toString path))
         && pkgs.lib.cleanSourceFilter path type;
     }).outPath;

--- a/theta/stack.yaml
+++ b/theta/stack.yaml
@@ -1,8 +1,8 @@
 resolver: lts-18.21
 extra-deps:
-- git: git@github.com:haskell-works/avro.git
+- git: https://github.com/haskell-works/avro.git
   commit: ae14b8c24c190c110767e1279ef76dd342a42486
-- git: git@github.com:stackbuilders/stache.git
+- git: https://github.com/stackbuilders/stache.git
   commit: f4e3b3f39efcdbb31588dd2a3f2fa73717094baf
 - aeson-2.0.3.0
 - OneTuple-0.3.1
@@ -11,4 +11,3 @@ extra-deps:
 - semialign-1.2.0.1
 - text-short-0.1.5
 - time-compat-1.9.6.1
-


### PR DESCRIPTION
Basic setup does a few things:

  1. Build Theta Haskell libraries + executables with Nix (including tests)
  2. Build Theta Haskell libraries + run tests with Stack
  3. Run cross-language tests with Nix
  
To reduce redundant work, I'm caching all of the Nix stuff with [Cachix][1] and the Stack depedencies with [actions/cache@v2][2]. Not entirely sure how well the caching is working for Stack—if it continues taking too long, I might either turn it off or only run it after merges to a staging branch or something...

[1]: https://app.cachix.org/cache/theta-idl#pull

[2]: https://github.com/actions/cache