### PR TITLE
Refactored tests to only run Stack tests on the staging branch

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -1,0 +1,31 @@
+# Base tests we can run on every commit/PR/etc
+#
+# Thanks to Nix caching, this will only run tests for components that
+# have changed since previous successful runs.
+name: Core Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v12
+
+      - name: Cachix
+        uses: cachix/cachix-action@v10
+        with:
+          name: theta-idl
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+      - name: Build Theta
+        run: nix-build theta
+
+      - name: Cross-Language Tests
+        run: nix-build test

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -1,12 +1,13 @@
-name: CI
+# Additional tests run on merge into stage
+name: Stage Tests
 
 on:
-  pull_request:
   push:
-  workflow_dispatch:
+    branches:
+      - 'stage'
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
 
     steps:
@@ -24,6 +25,9 @@ jobs:
       - name: Build Theta
         run: nix-build theta
 
+      - name: Cross-Language Tests
+        run: nix-build test
+
       - name: Cache Stack Dependencies
         uses: actions/cache@v2
         with:
@@ -36,6 +40,3 @@ jobs:
 
       - name: Stack Test
         run: ci/stack-test ./theta
-
-      - name: Cross-Language Tests
-        run: nix-build test


### PR DESCRIPTION
The Stack-specific tests are useful to make sure the Stack config doesn't break, but they're mostly redundant with the normal Nix-based tests and have worse caching. To fix this, I'm making two changes:

  1. Creating a `stage` branch as a pre-release branch in front of `main`. New features and fixes should go through `stage` before being merged into `main` (in batches?).
  2. The Stack-based tests will only be run when something is merged into `stage`, not on other commits and PRs.
  
I've been meaning to move to a separate `stage`/`main` kind of setup for a while. Not sure this is exactly what I want, but it seems reasonable for now and helps avoid running the Stack tests all the time. Down the line, I expect this setup will also help with release automation (tagging, uploading artifacts, pushing to Hackage/PyPI/etc).