### PR TITLE
Only run stack tests as part of stage.yml

### DIFF
--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -7,7 +7,7 @@ on:
       - 'stage'
 
 jobs:
-  test:
+  stack-test:
     runs-on: ubuntu-latest
 
     steps:
@@ -21,12 +21,6 @@ jobs:
         with:
           name: theta-idl
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-
-      - name: Build Theta
-        run: nix-build theta
-
-      - name: Cross-Language Tests
-        run: nix-build test
 
       - name: Cache Stack Dependencies
         uses: actions/cache@v2


### PR DESCRIPTION
Since *both* `core.yml` *and* `stage.yml` get run when a PR is merged into `stage`, it's redundant to run the core compile and tests steps from `stage.yml`