### PR TITLE
Fixed how the (-p|--path) argument gets parsed

### DIFF
--- a/theta/apps/Theta.hs
+++ b/theta/apps/Theta.hs
@@ -29,7 +29,7 @@ main :: IO ()
 main = do
   Encoding.setLocaleEncoding Encoding.utf8
 
-  options <- execParser parser
+  options <- customExecParser (prefs subparserInline) parser
   run options
   where parser =
           info ((version <|> thetaOptions) <**> helper)
@@ -78,8 +78,8 @@ version = flag' Version
   )
 
 thetaOptions :: Parser ThetaOptions
-thetaOptions = ThetaOptions <$> optional loadPath <*> subcommands
-  where loadPath = fromString <$> strOption
+thetaOptions = ThetaOptions <$> (mconcat <$> loadPath) <*> subcommands
+  where loadPath = some $ Just <$> strOption
           (  long "path"
           <> short 'p'
           <> metavar "THETA_LOAD_PATH"

--- a/theta/apps/Theta.hs
+++ b/theta/apps/Theta.hs
@@ -79,7 +79,7 @@ version = flag' Version
 
 thetaOptions :: Parser ThetaOptions
 thetaOptions = ThetaOptions <$> (mconcat <$> loadPath) <*> subcommands
-  where loadPath = some $ Just <$> strOption
+  where loadPath = many $ Just <$> strOption
           (  long "path"
           <> short 'p'
           <> metavar "THETA_LOAD_PATH"

--- a/theta/test/Test/Theta/Import.hs
+++ b/theta/test/Test/Theta/Import.hs
@@ -247,7 +247,7 @@ test_findInPath = testGroup "findInPath"
       a <- findInPath loadPath ("blarg" </> "foo.theta")
       a @?= Nothing
 
-      b <- findInPath "" "a.theta"
+      b <- findInPath "nope" "a.theta"
       b @?= Nothing
 
       c <- findInPath (LoadPath [dir </> root1]) "b.theta"


### PR DESCRIPTION
Previously, the `-p` argument had to come *before* subcommands and could only be passed in once:

``` shell
theta -p modules:more_modules avro all -m something
```

This was pretty annoying because I'd often type stuff like:

``` shell
theta avro all -p modules:more_modules -m something
```

which would produce an error.

This PR fixes this, allowing us to put `-p` anywhere as well as using it multiple times. This allows some flexibility for the `theta` command in scripts, like:

``` shell
theta -p base_modules \
      python \
      -p additional_python_modules \
      ...
```