### PR TITLE
Fixed how Name and ModuleName are displayed in error messages

### DIFF
--- a/theta/src/Theta/Name.hs
+++ b/theta/src/Theta/Name.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveAnyClass    #-}
 {-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE DerivingVia       #-}
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedLists   #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -11,8 +12,8 @@ module Theta.Name where
 
 import qualified Data.Char       as Char
 import           Data.Hashable   (Hashable)
-import           Data.Maybe      (fromMaybe)
 import qualified Data.Map        as Map
+import           Data.Maybe      (fromMaybe)
 import           Data.Text       (Text)
 import qualified Data.Text       as Text
 import           Data.Tree       (Tree (..))
@@ -23,7 +24,7 @@ import           GHC.Generics    (Generic)
 import           Test.QuickCheck (Arbitrary (..))
 import qualified Test.QuickCheck as QuickCheck
 
-import           Theta.Pretty    (Pretty (..))
+import           Theta.Pretty    (Pretty (..), ShowPretty (..))
 
 -- * Definitions
 
@@ -42,7 +43,10 @@ import           Theta.Pretty    (Pretty (..))
 -- worrying.
 data Name = Name { moduleName :: ModuleName
                  , name       :: Text
-                 } deriving (Show, Eq, Ord, Generic, Hashable)
+                 }
+  deriving stock (Eq, Ord, Generic)
+  deriving anyclass (Hashable)
+  deriving Show via ShowPretty Name
 
 -- | Parses string literals as dot-sperated names.
 --
@@ -154,7 +158,10 @@ render = pretty
 data ModuleName = ModuleName
   { namespace :: [Text]
   , baseName  :: Text
-  } deriving (Show, Eq, Ord, Generic, Hashable)
+  }
+  deriving stock (Eq, Ord, Generic)
+  deriving anyclass (Hashable)
+  deriving Show via ShowPretty ModuleName
 
 instance Pretty ModuleName where
   pretty = renderModuleName

--- a/theta/src/Theta/Pretty.hs
+++ b/theta/src/Theta/Pretty.hs
@@ -5,6 +5,7 @@
 -- display values in a consistent way.
 module Theta.Pretty
   ( Pretty(..)
+  , ShowPretty(..)
   , showPretty
   , p
   )
@@ -30,3 +31,17 @@ p = __i
 -- | The same as 'pretty' but returns a 'String'.
 showPretty :: Pretty a => a -> String
 showPretty = Text.unpack . pretty
+
+-- | A newtype that has a Show instance using 'showPretty' on the
+-- underlying type.
+--
+-- This is primarily designed for @DerivingVia@:
+--
+-- @
+-- data MyType = MyType {...}
+--   deriving Show via ShowPretty
+-- @
+newtype ShowPretty a = ShowPretty a
+
+instance Pretty a => Show (ShowPretty a) where
+  show (ShowPretty x) = showPretty x


### PR DESCRIPTION
Ideally, I'd like to change the `p` quasiquoter to use the `Pretty` class directly, but that looks like it will be difficult—I don't see any way of doing that on top of `string-interpolate` without modifying the library code directly.

Instead, I just changed the `Show` instances for both `Name` and `ModuleName` to use `Pretty`. To make this code a bit cleaner, I added a newtype `ShowPretty` that can be used with `DerivingVia`:

``` haskell
data MyType = MyType {...}
  deriving Show via ShowPretty MyType
```

Deriving via is pretty cool!