### PR TITLE
Removed Paths_theta module from lib: and exe: components

### DIFF
--- a/theta/src/Theta/Versions.hs
+++ b/theta/src/Theta/Versions.hs
@@ -20,8 +20,6 @@ import qualified Test.QuickCheck as QuickCheck
 
 import           Theta.Metadata (Version)
 
-import qualified Paths_theta
-
 -- * Language Versions
 
 -- | A version range with an /inclusive/ lower bound and an
@@ -71,9 +69,17 @@ avro = Range { name = "avro-version", lower = "1.0.0", upper = "1.2.0" }
 
 -- * Package Version
 
+-- Having the @theta@ library component depend on @Paths_theta@ caused
+-- unnecessary rebuilds with Stack (see GitHub issue[1]). To fix this,
+-- we hardcode the packageVersion in this module, then have a unit
+-- test that checks that it is up to date with the version in
+-- @Paths_theta@.
+--
+-- [1]: https://github.com/target/theta-idl/issues/37
+
 -- | Which version of the Theta package this is.
 packageVersion :: Cabal.Version
-packageVersion = Paths_theta.version
+packageVersion = Cabal.makeVersion [1, 0, 0, 0]
 
 -- | Which version of the Theta package this is as 'Text'.
 packageVersion' :: Text

--- a/theta/test/Test/Theta/Versions.hs
+++ b/theta/test/Test/Theta/Versions.hs
@@ -4,14 +4,23 @@ module Test.Theta.Versions where
 
 import           Theta.Versions
 
-import           Test.Tasty
-import           Test.Tasty.QuickCheck
+import           Test.Tasty            (TestTree, testGroup)
+import           Test.Tasty.HUnit      (testCase, (@?=))
+import           Test.Tasty.QuickCheck (testProperty)
+
+import           Paths_theta           (version)
 
 tests :: TestTree
-tests = testGroup "Versions" [ test_inRange ]
-
+tests = testGroup "Versions"
+  [ test_inRange
+  , test_packageVersion
+  ]
 
 test_inRange :: TestTree
 test_inRange = testProperty "inRange" $ \ version range ->
   inRange range version == (version >= lower range && -- inclusive inner
                             version <  upper range)   -- exclusive outer
+
+test_packageVersion :: TestTree
+test_packageVersion = testCase "packageVersion" $ do
+  packageVersion @?= Paths_theta.version

--- a/theta/theta.cabal
+++ b/theta/theta.cabal
@@ -100,8 +100,6 @@ library
 
                     , Theta.Target.Rust
                     , Theta.Target.Rust.QuasiQuoter
-  other-modules:      Paths_theta
-  autogen-modules:    Paths_theta
 
 test-suite tests
   import:             shared
@@ -163,9 +161,6 @@ executable theta
                     , Apps.Python
                     , Apps.Rust
                     , Apps.Subcommand
-
-                    , Paths_theta
-  autogen-modules:    Paths_theta
 
   if flag(isStatic)
     ghc-options: -optl=-static -optl=-pthread -static


### PR DESCRIPTION
Depending on the autogenerated `Paths_theta` module causes unnecessary rebuilds on Stack (see #37). Depending on `Paths_theta` from the test suite does not cause the same problem since the project can be configured with tests disabled.

Since we only used `Paths_theta` in the library to get the package version (in `Theta.Version`), the easiest solution was to hardcode the version in the library and use a unit test to make sure it's up to date. This is a bit hacky and manual, but the unit test will keep me from forgetting to update the hardcoded version so it isn't a big deal in practice.