### PR TITLE
Remove Avro rendering restriction on top-level schemas

### DIFF
--- a/theta/apps/Apps/Avro.hs
+++ b/theta/apps/Apps/Avro.hs
@@ -7,7 +7,7 @@
 
 module Apps.Avro where
 
-import           Control.Monad           (forM_, when)
+import           Control.Monad           (forM_)
 import           Control.Monad.IO.Class  (liftIO)
 
 import qualified Data.Aeson              as Aeson

--- a/theta/apps/Apps/Avro.hs
+++ b/theta/apps/Apps/Avro.hs
@@ -119,21 +119,17 @@ runAll AllOptions { target, moduleNames } loadPath = do
 
   forM_ (Theta.transitiveImports modules) $ \ module_ -> do
     forM_ (Theta.types module_) $ \ definition ->
-      when (isExportable $ Theta.definitionType definition) $
-        export (Theta.moduleName module_) definition
+      export (Theta.moduleName module_) definition
 
-  where isExportable Theta.Type { Theta.baseType = Theta.Record' {} }  = True
-        isExportable Theta.Type { Theta.baseType = Theta.Variant' {} } = True
-        isExportable _                                                 = False
+  where 
+      export moduleName definition = do
+        schema <- toSchema definition
+        liftIO $ do
+          let path = Text.unpack <$> Name.moduleParts moduleName
+              out  = target </> "avro" </> joinPath path
+          createDirectoryIfMissing True out
 
-        export moduleName definition = do
-          schema <- toSchema definition
-          liftIO $ do
-            let path = Text.unpack <$> Name.moduleParts moduleName
-                out  = target </> "avro" </> joinPath path
-            createDirectoryIfMissing True out
-
-            let filename =
-                  Text.unpack $ Name.name $ Theta.definitionName definition
-            LBS.writeFile (out </> filename <.> "avsc") $ Aeson.encode schema
+          let filename =
+                Text.unpack $ Name.name $ Theta.definitionName definition
+          LBS.writeFile (out </> filename <.> "avsc") $ Aeson.encode schema
 

--- a/theta/src/Theta/Target/Avro/Types.hs
+++ b/theta/src/Theta/Target/Avro/Types.hs
@@ -61,8 +61,7 @@ import           Theta.Target.Avro.Error
 import           Theta.Types
 import qualified Theta.Versions             as Versions
 
--- | Transform a compatible Theta type into a full Avro schema. This
--- will only work with Theta records and variants.
+-- | Transform a Theta type into a full Avro schema.
 --
 -- The resulting Avro schema is /self-contained/. This means that any
 -- referenced type (record, variant... etc) is included in the schema


### PR DESCRIPTION
Inspired by discussion in https://github.com/target/theta-idl/pull/39, a minimal attempt to remove the restrictions on top-level schema rendering.

This seems to behave well in my own testing (outside of nix), would be great if you could give it a look over to see if this all seems sensible to you @TikhonJelvis.

Not sure which branch you'd prefer me to base off here but I am working from `stage`.