### PR TITLE
Fix Python code generation with --prefix + namespaces

### DIFF
--- a/test/python/modules/com/example/importing_nested.theta
+++ b/test/python/modules/com/example/importing_nested.theta
@@ -1,0 +1,13 @@
+language-version: 1.0.0
+avro-version: 1.0.0
+---
+
+// This import would break older versions of the Python code generator
+// when used with an explicit prefix
+//
+// See: https://github.com/target/theta-idl/issues/43
+import com.example.nested
+
+type ImportingNested = {
+    test_field : com.example.nested.TestRecord
+}

--- a/test/python/modules/com/example/nested.theta
+++ b/test/python/modules/com/example/nested.theta
@@ -1,0 +1,9 @@
+language-version: 1.0.0
+avro-version: 1.0.0
+---
+
+/// Just a record so that we can generate an Avro schema for this
+/// module
+type TestRecord = {
+    test_field : Int
+}

--- a/test/python/modules/python_tests.theta
+++ b/test/python/modules/python_tests.theta
@@ -19,3 +19,5 @@ import variant
 import newtype
 
 import shadowing
+
+import com.example.importing_nested

--- a/test/python/theta_python_tests/test_python.py
+++ b/test/python/theta_python_tests/test_python.py
@@ -15,6 +15,9 @@ from theta_python_tests.newtype import NewtypeRecord
 
 import theta_python_tests.shadowing as shadowing
 
+import theta_python_tests.com.example.nested as nested
+import theta_python_tests.com.example.importing_nested as importing_nested
+
 ints = integers(min_value=-0x80000000, max_value=0x7FFFFFFF)
 longs = integers(min_value=-0x8000000000000000, max_value=0x7FFFFFFFFFFFFFFF)
 
@@ -100,6 +103,14 @@ class TestShadowing(unittest.TestCase):
     def test_primitives(self, record):
         wrapped = shadowing.Primitives(underlying=record)
         round_trip(wrapped, shadowing.Primitives)
+
+
+class TestImportingNested(unittest.TestCase):
+    @given(ints)
+    def test_importing_nested(self, i):
+        nested_record = nested.TestRecord(i)
+        wrapped = importing_nested.ImportingNested(nested_record)
+        round_trip(wrapped, importing_nested.ImportingNested)
 
 
 class TestFixedContainers(unittest.TestCase):

--- a/theta/test/data/python/importing_foo_qualified.mustache
+++ b/theta/test/data/python/importing_foo_qualified.mustache
@@ -7,4 +7,4 @@ from typing import Any, ClassVar, Dict, Iterator, List, Mapping, Optional
 
 from theta import avro, container
 
-import theta.foo as foo
+import theta.foo


### PR DESCRIPTION
Before this PR, Theta would generate invalid Python code when:

  1. using an extra prefix (`theta python --prefix prefix`) and
  2. importing a module from a namespace (`import example.module_name`)

resulting in:

``` python
import prefix.example.module_name as example.module_name
```

which is not valid Python syntax. (See #43 for more details.)

This PR fixes this by using the prefix when referring to imported identifiers. Now the import would look like this instead:

``` python
import prefix.example.module_name
```

and references to identifiers will now be verbose:

``` python
field: prefix.example.module_name.TypeName
```

An alternative design would have been to have some method for generating a valid, shorter name for the module being imported, like:

``` python
import prefix.example.module_name as module_name
```

However, this would either risk failing on duplicate names or require some kind of explicit deduplication logic. Using fully qualified names avoids these problems but results in more verbose code—since the code is generated, this seems like a reasonable compromise.