### PR TITLE
Fix indentation for enum in theta.el

### DIFF
--- a/emacs/theta-mode.el
+++ b/emacs/theta-mode.el
@@ -100,9 +100,11 @@
       (version-separator (version "---" statement))
       (version-number)
 
-      (statement ("import" id)
-                 ("type" type-definition)
-                 ("alias" alias-definition))
+      (statement
+       ("import" id)
+       ("type" type-definition)
+       ("enum" type-definition)
+       ("alias" alias-definition))
 
       (type-definition (id "=" type-body))
       (alias-definition (id "=" id))
@@ -136,6 +138,7 @@
     ;; Top-level keywords never need to be indented (declarations like
     ;; `type Foo = ...` always start at the beginning of the line)
     (`(:before . "type") '(column . 0))
+    (`(:before . "enum") '(column . 0))
     (`(:before . "alias") '(column . 0))
     (`(:before . "import") '(column . 0))
 


### PR DESCRIPTION
I added `enum` to the list of keywords that always indents at column 0. This should help with #45.

I haven't tested this change at all. I'm not at my normal computer right now, but since this seems to be a one-line change I did it from GitHub's online interface. Pretty sure it works, but I've been wrong about stuff like that too often to be entirely confident :P