### PR TITLE
Extracted primitive types into a dedicated type + module

### DIFF
--- a/test/hash/default.nix
+++ b/test/hash/default.nix
@@ -9,23 +9,23 @@ let
   expected-1 = pkgs.writeTextFile {
     name = "theta-hash-expected-1";
     text = ''
-      foo.Bar	4297466238902a227cd7992783897452
-      foo.Baz	74aa1ef0f5de1b09a4eec622127f42d5
+      foo.Bar	acbc45ad628ebccf04ec52d0d275a57c
+      foo.Baz	261517de3a75f9f11bbdb3b496e08381
     '';
   };
   expected-2 = pkgs.writeTextFile {
     name = "theta-hash-expected-2";
     text = ''
-      other.Other	06d2243dbfaeca8808608638d9c05d23
-      other.OtherThing	20211f5221e58b43230122e99f51b6e4
-      foo.Bar	4297466238902a227cd7992783897452
-      foo.Baz	74aa1ef0f5de1b09a4eec622127f42d5
+      other.Other	a6fd63eefd826a232fb8bfc551200c1e
+      other.OtherThing	814fc5791e3990d5f55d07e48f560889
+      foo.Bar	acbc45ad628ebccf04ec52d0d275a57c
+      foo.Baz	261517de3a75f9f11bbdb3b496e08381
     '';
   };
   expected-enum = pkgs.writeTextFile {
     name = "theta-hash-expected-enum";
     text = ''
-      enum.Foo	10ac7250eaaf54a514d6a7789ec45570
+      enum.Foo	c8cf29e0b679d8fd4878ff397292ca56
     '';
   };
 in

--- a/theta/src/Theta/Hash.hs
+++ b/theta/src/Theta/Hash.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings          #-}
+-- | Theta types carry a unique, structural hash for quick equality
+-- comparisons.
+--
+-- Two equivalent types will always have the same hash. A reference to
+-- a type will have the same hash as the type itself.
+--
+-- The hashing implementation may change in different versions of
+-- Theta, so you should not rely on hashes being stable across
+-- releases of the @theta@ package.
+module Theta.Hash where
+
+import           Data.Binary          (Binary, encode)
+import qualified Data.ByteString.Lazy as LBS
+import           Data.Digest.Pure.MD5 (MD5Digest, md5)
+import           Data.Text            (Text)
+import qualified Data.Text.Encoding   as Text
+
+-- | The output of our hashing function.
+--
+-- Currently uses MD5 under the hood, but this might change in the
+-- future—don't rely on the hashing implementation directly.
+newtype Hash = Hash MD5Digest
+  deriving newtype (Binary, Show, Eq, Ord)
+
+instance Semigroup Hash where
+  Hash a <> Hash b = toHash $ encode a <> encode b
+
+-- | The hashing function we're using. Designed to be easy to
+-- change—just change this function + the type underneath 'Hash'.
+toHash :: LBS.ByteString -> Hash
+toHash = Hash . md5
+
+-- | Calculate a hash for the given text. This doesn't do any extra
+-- processing, so differences in whitespace/etc will produce different
+-- hashes.
+hashText :: Text -> Hash
+hashText = toHash . LBS.fromStrict . Text.encodeUtf8
+
+-- | Calculate a canonical hash for a list of hashes.
+--
+-- This lets us consistently hash multiple hashable values in a given
+-- order.
+hashList :: [Hash] -> Hash
+hashList = foldr (<>) (hashText "")

--- a/theta/src/Theta/Import.hs
+++ b/theta/src/Theta/Import.hs
@@ -285,7 +285,7 @@ resolveModule loadPath moduleName ModuleDefinition { header, body } = do
     []   -> pure (finalModule, paths)
     errs -> throwError $ InvalidModule errs
   where
-    resolve finalModule = foldM go (Module moduleName Map.empty [] header, []) body
+    resolve finalModule = foldM go (emptyModule moduleName header, []) body
       where
         go (module_, dependencies) (DefinitionStatement definition)  = do
           let Definition {..} = definition

--- a/theta/src/Theta/Name.hs
+++ b/theta/src/Theta/Name.hs
@@ -24,6 +24,7 @@ import           GHC.Generics    (Generic)
 import           Test.QuickCheck (Arbitrary (..))
 import qualified Test.QuickCheck as QuickCheck
 
+import           Theta.Hash      (Hash, hashList, hashText)
 import           Theta.Pretty    (Pretty (..), ShowPretty (..))
 
 -- * Definitions
@@ -79,6 +80,11 @@ randomPart = do
 
         randomList =
           QuickCheck.resize 20 . QuickCheck.listOf . QuickCheck.elements
+
+-- | Calculate the hash for a fully qualified name. This considers
+-- both the base name *and* the namespace.
+hashName :: Name -> Hash
+hashName = hashList . map hashText . parts
 
 -- | Return the parts of a name (ie module name and base name) as a
 -- list.

--- a/theta/src/Theta/Primitive.hs
+++ b/theta/src/Theta/Primitive.hs
@@ -1,0 +1,102 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE OverloadedStrings  #-}
+-- | Theta supports a number of "primitive" types that have built-in
+-- encodings and behaviors.
+--
+-- Based on [Avro's primitive
+-- types](https://avro.apache.org/docs/current/spec.html#schema_primitive):
+--
+--   * Bool
+--   * Bytes
+--   * Int
+--   * Long
+--   * Float
+--   * Double
+--   * String
+--
+-- Based on [Avro's logical
+-- types](https://avro.apache.org/docs/current/spec.html#Logical+Types):
+--
+--   * Date
+--   * Datetime
+module Theta.Primitive where
+
+import           Data.Text      (Text)
+import qualified Data.Text      as Text
+
+import           Theta.Hash     (Hash)
+import           Theta.Metadata (Version)
+import           Theta.Name     (Name, hashName)
+import           Theta.Pretty   (Pretty, pretty)
+
+-- | Theta's primitive types.
+--
+-- A primitive type has its own encoding and behavior—can be
+-- fundamentally different from user-defined types.
+data Primitive = Bool
+               | Bytes
+               -- ^ A variable-length byte array—can store binary
+               -- blobs
+               | Int
+               -- ^ 32-bit signed integers
+               | Long
+               -- ^ 64-bit signed integers
+               | Float
+               -- ^ 32-bit floating-point numbers
+               | Double
+               -- ^ 64-bit floating-point numbers
+               | String
+               -- ^ Unicode-aware strings
+               | Date
+               -- ^ An absolute date (eg @2020-01-10@) with no time
+               -- attached
+               | Datetime
+               -- ^ An absolute timestamp in UTC (no locale/timezone)
+ deriving stock (Eq, Show, Ord, Enum, Bounded)
+
+instance Pretty Primitive where pretty = primitiveKeyword
+
+-- | Returns a canonical name for each primitive type.
+--
+-- Primitive types have definitions in the @theta.primitive@ module,
+-- so that's the canonical namespace. @Int@ become
+-- @theta.primitive.Int@, @String@ becomes
+-- @theta.primitive.String@... etc.
+primitiveName :: Primitive -> Name
+primitiveName Bool     = "theta.primitive.Bool"
+primitiveName Bytes    = "theta.primitive.Bytes"
+primitiveName Int      = "theta.primitive.Int"
+primitiveName Long     = "theta.primitive.Long"
+primitiveName Float    = "theta.primitive.Float"
+primitiveName Double   = "theta.primitive.Double"
+primitiveName String   = "theta.primitive.String"
+primitiveName Date     = "theta.primitive.Date"
+primitiveName Datetime = "theta.primitive.Datetime"
+
+-- | The canonical keyword for each primitive type.
+--
+-- Currently this is automatically derived from the 'Show' instance
+-- for 'Primitive', but this is not guaranteed to hold in the future.
+primitiveKeyword :: Primitive -> Text
+primitiveKeyword = Text.pack . show
+
+-- | Return a canonical hash for each primitive type.
+hashPrimitive :: Primitive -> Hash
+hashPrimitive = hashName . primitiveName
+
+-- | The earliest @language-version@ that supports the given primitive
+-- type.
+definedIn :: Primitive -> Version
+definedIn Bool     = "1.0.0"
+definedIn Bytes    = "1.0.0"
+definedIn Int      = "1.0.0"
+definedIn Long     = "1.0.0"
+definedIn Float    = "1.0.0"
+definedIn Double   = "1.0.0"
+definedIn String   = "1.0.0"
+definedIn Date     = "1.0.0"
+definedIn Datetime = "1.0.0"
+
+-- | Every single primitive type supported by Theta.
+primitives :: [Primitive]
+primitives = [minBound..maxBound]

--- a/theta/src/Theta/Target/Avro/Values.hs
+++ b/theta/src/Theta/Target/Avro/Values.hs
@@ -66,6 +66,7 @@ import           Theta.Value
 
 import           Data.Time                   (picosecondsToDiffTime)
 import           Debug.Trace
+import qualified Theta.Primitive             as Theta
 
 trace' :: Show a => String -> a -> a
 trace' label a = trace (label <> ":\n" <> show a <> "\n") a
@@ -89,15 +90,21 @@ toAvro value@Value { type_ } = do
           (ReadSchema.NamedType name, _)  -> go env (env name) v
 
           -- primitive types
-          (ReadSchema.Boolean, Boolean b)   -> Avro.Boolean b
-          (ReadSchema.Bytes _, Bytes bs)    -> Avro.Bytes schema (LBS.toStrict bs)
-          (ReadSchema.Int _, Int i)         -> Avro.Int schema i
-          (ReadSchema.Long _ _, Long l)     -> Avro.Long schema l
-          (ReadSchema.Float _, Float f)     -> Avro.Float schema f
-          (ReadSchema.Double _, Double d)   -> Avro.Double schema d
-          (ReadSchema.String _, String t)   -> Avro.String schema t
-          (ReadSchema.Int _, Date d)        -> Avro.Int schema $ fromDay d
-          (ReadSchema.Long _ _, Datetime t) -> Avro.Long schema $ fromUTCTime t
+          (readSchema, Primitive v) -> case (readSchema, v) of
+            (ReadSchema.Boolean, Boolean b)   -> Avro.Boolean b
+            (ReadSchema.Bytes _, Bytes bs)    -> Avro.Bytes schema (LBS.toStrict bs)
+            (ReadSchema.Int _, Int i)         -> Avro.Int schema i
+            (ReadSchema.Long _ _, Long l)     -> Avro.Long schema l
+            (ReadSchema.Float _, Float f)     -> Avro.Float schema f
+            (ReadSchema.Double _, Double d)   -> Avro.Double schema d
+            (ReadSchema.String _, String t)   -> Avro.String schema t
+            (ReadSchema.Int _, Date d)        -> Avro.Int schema $ fromDay d
+            (ReadSchema.Long _ _, Datetime t) -> Avro.Long schema $ fromUTCTime t
+
+            (_, _) -> error $ "Mismatch between the type_ and value of a Value. \
+                              \This is a bug in the Theta implementation.\n"
+                           <> show readSchema <> "\n" <> show v
+
 
           -- containers
           (ReadSchema.Array t, Array vs)                    ->
@@ -217,16 +224,17 @@ fromAvro type_@Theta.Type { baseType, module_ } avro = do
             Right t -> recurse t avro
 
           -- primitive types
-          (Theta.Bool', Avro.Boolean b)    -> pure $ Boolean b
-          (Theta.Int', Avro.Int _ i)       -> pure $ Int i
-          (Theta.Long', Avro.Long _ l)     -> pure $ Long l
-          (Theta.Float', Avro.Float _ f)   -> pure $ Float f
-          (Theta.Double', Avro.Double _ d) -> pure $ Double d
-          (Theta.Bytes', Avro.Bytes _ bs)  -> pure $ Bytes $ LBS.fromStrict bs
-          (Theta.String', Avro.String _ t) -> pure $ String t
-
-          (Theta.Date', Avro.Int _ i)      -> pure $ Date $ toDay i
-          (Theta.Datetime', Avro.Long _ i) -> pure $ Datetime $ toUTCTime i
+          (Theta.Primitive' t, avro) -> case (t, avro) of
+            (Theta.Bool, Avro.Boolean b)    -> wrapPrimitive $ Boolean b
+            (Theta.Bytes, Avro.Bytes _ bs)  -> wrapPrimitive $ Bytes $ LBS.fromStrict bs
+            (Theta.Int, Avro.Int _ i)       -> wrapPrimitive $ Int i
+            (Theta.Long, Avro.Long _ l)     -> wrapPrimitive $ Long l
+            (Theta.Float, Avro.Float _ f)   -> wrapPrimitive $ Float f
+            (Theta.Double, Avro.Double _ d) -> wrapPrimitive $ Double d
+            (Theta.String, Avro.String _ t) -> wrapPrimitive $ String t
+            (Theta.Date, Avro.Int _ i)      -> wrapPrimitive $ Date $ toDay i
+            (Theta.Datetime, Avro.Long _ l) -> wrapPrimitive $ Datetime $ toUTCTime l
+            (_, got)                        -> throw $ TypeMismatch type_ got
 
           -- containers
           (Theta.Array' t, Avro.Array xs)   ->
@@ -257,6 +265,8 @@ fromAvro type_@Theta.Type { baseType, module_ } avro = do
           (Theta.Newtype' _ t, v)           -> recurse t v
 
           (_, got)                          -> throw $ TypeMismatch type_ got
+
+        wrapPrimitive = pure . Primitive
 
         fieldSchemas :: ReadSchema.ReadSchema
                      -> Vector Avro.Value

--- a/theta/src/Theta/Target/Haskell/Conversion.hs
+++ b/theta/src/Theta/Target/Haskell/Conversion.hs
@@ -159,8 +159,8 @@ instance ToTheta Bool where
 
 instance FromTheta Bool where
   fromTheta' Theta.Value { Theta.type_, Theta.value } = case value of
-    Theta.Boolean b -> pure b
-    _               -> mismatch Theta.bool' type_
+    Theta.Primitive (Theta.Boolean b) -> pure b
+    _                                 -> mismatch Theta.bool' type_
 
   avroDecoding = Avro.getBoolean
 
@@ -171,8 +171,8 @@ instance ToTheta ByteString where
 
 instance FromTheta ByteString where
   fromTheta' Theta.Value { Theta.type_, Theta.value } = case value of
-    Theta.Bytes b -> pure b
-    _             -> mismatch Theta.bytes' type_
+    Theta.Primitive (Theta.Bytes b) -> pure b
+    _                               -> mismatch Theta.bytes' type_
 
   avroDecoding = Avro.getBytesLazy
 
@@ -183,8 +183,8 @@ instance ToTheta Int32 where
 
 instance FromTheta Int32 where
   fromTheta' Theta.Value { Theta.type_, Theta.value } = case value of
-    Theta.Int i -> pure i
-    _           -> mismatch Theta.int' type_
+    Theta.Primitive (Theta.Int i) -> pure i
+    _                             -> mismatch Theta.int' type_
 
 instance ToTheta Int64 where
   toTheta = Theta.long
@@ -193,8 +193,8 @@ instance ToTheta Int64 where
 
 instance FromTheta Int64 where
   fromTheta' Theta.Value { Theta.type_, Theta.value } = case value of
-    Theta.Long l -> pure l
-    _            -> mismatch Theta.long' type_
+    Theta.Primitive (Theta.Long l) -> pure l
+    _                              -> mismatch Theta.long' type_
 
 instance ToTheta Float where
   toTheta = Theta.float
@@ -203,8 +203,8 @@ instance ToTheta Float where
 
 instance FromTheta Float where
   fromTheta' Theta.Value { Theta.type_, Theta.value } = case value of
-    Theta.Float f -> pure f
-    _             -> mismatch Theta.float' type_
+    Theta.Primitive (Theta.Float f) -> pure f
+    _                               -> mismatch Theta.float' type_
 
   avroDecoding = Avro.getFloat
 
@@ -215,8 +215,8 @@ instance ToTheta Double where
 
 instance FromTheta Double where
   fromTheta' Theta.Value { Theta.type_, Theta.value } = case value of
-    Theta.Double d -> pure d
-    _              -> mismatch Theta.double' type_
+    Theta.Primitive (Theta.Double d) -> pure d
+    _                                -> mismatch Theta.double' type_
 
   avroDecoding = Avro.getDouble
 
@@ -227,8 +227,8 @@ instance ToTheta Text where
 
 instance FromTheta Text where
   fromTheta' Theta.Value { Theta.type_, Theta.value } = case value of
-    Theta.String s -> pure s
-    _              -> mismatch Theta.string' type_
+    Theta.Primitive (Theta.String s) -> pure s
+    _                                -> mismatch Theta.string' type_
 
   avroDecoding = Avro.getString
 
@@ -239,8 +239,8 @@ instance ToTheta Day where
 
 instance FromTheta Day where
   fromTheta' Theta.Value { Theta.type_, Theta.value } = case value of
-    Theta.Date day -> pure day
-    _              -> mismatch Theta.date' type_
+    Theta.Primitive (Theta.Date day) -> pure day
+    _                                -> mismatch Theta.date' type_
 
   avroDecoding = Values.toDay <$> DecodeRaw.decodeRaw @Int32
 
@@ -251,8 +251,8 @@ instance ToTheta UTCTime where
 
 instance FromTheta UTCTime where
   fromTheta' Theta.Value { Theta.type_, Theta.value } = case value of
-    Theta.Datetime time -> pure time
-    _                   -> mismatch Theta.datetime' type_
+    Theta.Primitive (Theta.Datetime time) -> pure time
+    _                                     -> mismatch Theta.datetime' type_
 
   avroDecoding = Values.toUTCTime <$> DecodeRaw.decodeRaw @Int64
 

--- a/theta/src/Theta/Target/Kotlin.hs
+++ b/theta/src/Theta/Target/Kotlin.hs
@@ -28,6 +28,7 @@ import           Theta.Name                      (ModuleName, Name)
 import qualified Theta.Name                      as Name
 import qualified Theta.Types                     as Theta
 
+import qualified Theta.Primitive                 as Theta
 import           Theta.Target.Kotlin.QuasiQuoter (Kotlin (..), kotlin)
 
 -- | Compile a Theta module to a single Kotlin file.
@@ -172,15 +173,16 @@ toReference :: Theta.Type -> Kotlin
 toReference Theta.Type { Theta.baseType } = case baseType of
 
   -- primitive types
-  Theta.Bool'           -> [kotlin|Boolean|]
-  Theta.Bytes'          -> [kotlin|ByteArray|]
-  Theta.Int'            -> [kotlin|Int|]
-  Theta.Long'           -> [kotlin|Long|]
-  Theta.Float'          -> [kotlin|Float|]
-  Theta.Double'         -> [kotlin|Double|]
-  Theta.String'         -> [kotlin|String|]
-  Theta.Date'           -> [kotlin|LocalDate|]
-  Theta.Datetime'       -> [kotlin|LocalDateTime|]
+  Theta.Primitive' t -> case t of
+    Theta.Bool     -> [kotlin|Boolean|]
+    Theta.Bytes    -> [kotlin|ByteArray|]
+    Theta.Int      -> [kotlin|Int|]
+    Theta.Long     -> [kotlin|Long|]
+    Theta.Float    -> [kotlin|Float|]
+    Theta.Double   -> [kotlin|Double|]
+    Theta.String   -> [kotlin|String|]
+    Theta.Date     -> [kotlin|LocalDate|]
+    Theta.Datetime -> [kotlin|LocalDateTime|]
 
   -- containers
   Theta.Array' a        -> let items = toReference a in [kotlin|Array<$items>|]

--- a/theta/src/Theta/Target/Rust.hs
+++ b/theta/src/Theta/Target/Rust.hs
@@ -46,6 +46,7 @@ import qualified Theta.Types                   as Theta
 
 import           Theta.Target.Haskell          (disambiguateConstructors)
 
+import qualified Theta.Primitive               as Theta
 import           Theta.Target.Rust.QuasiQuoter (Rust (..), rust)
 
 -- | Given a set of modules, generate a self-contained Rust file with
@@ -138,10 +139,10 @@ toDefinition Theta.Definition {..} = case Theta.baseType definitionType of
 -- ignoring namespaces.
 toReference :: Theta.Type -> Rust
 toReference type_@Theta.Type { Theta.baseType } = case baseType of
-  -- primitive types
-  Theta.Bytes'      -> [rust|Vec<u8>|]
-  Theta.Date'       -> [rust|Date<Utc>|]
-  Theta.Datetime'   -> [rust|DateTime<Utc>|]
+  -- special cases for primitive types
+  Theta.Primitive' Theta.Bytes    -> [rust|Vec<u8>|]
+  Theta.Primitive' Theta.Date     -> [rust|Date<Utc>|]
+  Theta.Primitive' Theta.Datetime -> [rust|DateTime<Utc>|]
 
   -- containers
   Theta.Array' a    -> let ref = toReference a in [rust|Vec<$ref>|]
@@ -164,15 +165,16 @@ toReference type_@Theta.Type { Theta.baseType } = case baseType of
 typeIdentifier :: Theta.Type -> [Rust]
 typeIdentifier Theta.Type { Theta.baseType } = case baseType of
   -- primitive types
-  Theta.Bool'           -> ["bool"]
-  Theta.Bytes'          -> ["Vec"]
-  Theta.Int'            -> ["i32"]
-  Theta.Long'           -> ["i64"]
-  Theta.Float'          -> ["f32"]
-  Theta.Double'         -> ["f64"]
-  Theta.String'         -> ["String"]
-  Theta.Date'           -> ["Date"]
-  Theta.Datetime'       -> ["DateTime"]
+  Theta.Primitive' p -> case p of
+    Theta.Bool     -> ["bool"]
+    Theta.Bytes    -> ["Vec"]
+    Theta.Int      -> ["i32"]
+    Theta.Long     -> ["i64"]
+    Theta.Float    -> ["f32"]
+    Theta.Double   -> ["f64"]
+    Theta.String   -> ["String"]
+    Theta.Date     -> ["Date"]
+    Theta.Datetime -> ["DateTime"]
 
   -- containers
   Theta.Array' _        -> ["Vec"]
@@ -946,18 +948,8 @@ refersTo t@Theta.Type { Theta.module_ } name =
             | otherwise               -> whenUnseen name' $
               or <$> mapM fieldsReference (Theta.caseParameters <$> cases)
 
-          -- primitive types
-          -- (listed explicitly to raise a warning if we add new kinds of
-          -- types to Theta)
-          Theta.Bool'     -> pure False
-          Theta.Bytes'    -> pure False
-          Theta.Int'      -> pure False
-          Theta.Long'     -> pure False
-          Theta.Float'    -> pure False
-          Theta.Double'   -> pure False
-          Theta.String'   -> pure False
-          Theta.Date'     -> pure False
-          Theta.Datetime' -> pure False
+          -- primitive types can never refer to another type
+          Theta.Primitive' _ -> pure False
 
         names cases = Theta.caseName <$> cases
 

--- a/theta/src/Theta/Value.hs
+++ b/theta/src/Theta/Value.hs
@@ -1,7 +1,8 @@
-{-# LANGUAGE NamedFieldPuns   #-}
-{-# LANGUAGE NumDecimals      #-}
-{-# LANGUAGE ParallelListComp #-}
-{-# LANGUAGE ViewPatterns     #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE NamedFieldPuns     #-}
+{-# LANGUAGE NumDecimals        #-}
+{-# LANGUAGE ParallelListComp   #-}
+{-# LANGUAGE ViewPatterns       #-}
 -- | This module defines the 'Value' type which is a generic
 -- representation of values that satisfy some Theta schema. The
 -- 'Value' type gives us an intermediate representation that helps us
@@ -33,19 +34,26 @@ import           Test.QuickCheck      (Arbitrary (arbitrary), Gen, choose,
                                        elements, frequency, listOf, scale)
 
 import           Theta.Name           (Name)
+import qualified Theta.Primitive      as Theta
 import qualified Theta.Types          as Theta
+
+-- | A value of a primitive type.
+data PrimitiveValue =
+    Boolean !Bool
+  | Bytes !ByteString
+  | Int {-# UNPACK #-} !Int32
+  | Long {-# UNPACK #-} !Int64
+  | Float {-# UNPACK #-} !Float
+  | Double {-# UNPACK #-} !Double
+  | String {-# UNPACK #-} !Text
+  | Date !Day
+  | Datetime {-# UNPACK #-} !UTCTime
+  deriving stock (Show, Eq)
 
 -- | A generic representation of data that could be represented by a
 -- Theta schema.
-data BaseValue = Boolean !Bool
-               | Bytes !ByteString
-               | Int {-# UNPACK #-} !Int32
-               | Long {-# UNPACK #-} !Int64
-               | Float {-# UNPACK #-} !Float
-               | Double {-# UNPACK #-} !Double
-               | String {-# UNPACK #-} !Text
-               | Date !Day
-               | Datetime {-# UNPACK #-} !UTCTime
+data BaseValue = Primitive PrimitiveValue
+                 -- ^ Values of primitive types.
 
                | Array {-# UNPACK #-} !(Vector Value)
                  -- ^ Each 'Value' in an array should have the same
@@ -97,31 +105,31 @@ data Value = Value
 -- called "base" ('Theta.baseModule').
 
 boolean :: Bool -> Value
-boolean = Value Theta.bool' . Boolean
+boolean = Value Theta.bool' . Primitive . Boolean
 
 bytes :: ByteString -> Value
-bytes = Value Theta.bytes' . Bytes
+bytes = Value Theta.bytes' . Primitive . Bytes
 
 int :: Int32 -> Value
-int = Value Theta.int' . Int
+int = Value Theta.int' . Primitive . Int
 
 long :: Int64 -> Value
-long = Value Theta.long' . Long
+long = Value Theta.long' . Primitive . Long
 
 float :: Float -> Value
-float = Value Theta.float' . Float
+float = Value Theta.float' . Primitive . Float
 
 double :: Double -> Value
-double = Value Theta.double' . Double
+double = Value Theta.double' . Primitive . Double
 
 string :: Text -> Value
-string = Value Theta.string' . String
+string = Value Theta.string' . Primitive . String
 
 date :: Day -> Value
-date = Value Theta.date' . Date
+date = Value Theta.date' . Primitive . Date
 
 datetime :: UTCTime -> Value
-datetime = Value Theta.datetime' . Datetime
+datetime = Value Theta.datetime' . Primitive . Datetime
 
 -- * Testing
 
@@ -130,15 +138,17 @@ checkBaseValue :: Theta.Type -> BaseValue -> Bool
 checkBaseValue Theta.Type { Theta.baseType, Theta.module_ } baseValue =
   case (baseType, baseValue) of
     -- primitives
-    (Theta.Bool', Boolean{})      -> True
-    (Theta.Bytes', Bytes{})       -> True
-    (Theta.Int', Int{})           -> True
-    (Theta.Long', Long{})         -> True
-    (Theta.Float', Float{})       -> True
-    (Theta.Double', Double{})     -> True
-    (Theta.String', String{})     -> True
-    (Theta.Date', Date{})         -> True
-    (Theta.Datetime', Datetime{}) -> True
+    (Theta.Primitive' t, Primitive v) -> case (t, v) of
+      (Theta.Bool, Boolean _)      -> True
+      (Theta.Bytes, Bytes _)       -> True
+      (Theta.Int, Int _)           -> True
+      (Theta.Long, Long _)         -> True
+      (Theta.Float, Float _)       -> True
+      (Theta.Double, Double _)     -> True
+      (Theta.String, String _)     -> True
+      (Theta.Date, Date _)         -> True
+      (Theta.Datetime, Datetime _) -> True
+      (_, _)                       -> False
 
     -- containers
     (Theta.Array' item, Array values) ->
@@ -210,15 +220,16 @@ checkValue Value { value, type_ } = checkBaseValue type_ value
 genValue' :: HashMap Name (Gen Value) -> Theta.Type -> Gen Value
 genValue' overrides = go
   where go t = case Theta.baseType t of
-          Theta.Bool'          -> boolean <$> arbitrary
-          Theta.Bytes'         -> bytes . LBS.pack <$> arbitrary
-          Theta.Int'           -> int <$> arbitrary
-          Theta.Long'          -> long <$> arbitrary
-          Theta.Float'         -> float <$> arbitrary
-          Theta.Double'        -> double <$> arbitrary
-          Theta.String'        -> string . Text.pack <$> arbitrary
-          Theta.Date'          -> date <$> genDate
-          Theta.Datetime'      -> datetime <$> genDatetime
+          Theta.Primitive' t -> case t of
+            Theta.Bool     -> boolean <$> arbitrary
+            Theta.Bytes    -> bytes . LBS.pack <$> arbitrary
+            Theta.Int      -> int <$> arbitrary
+            Theta.Long     -> long <$> arbitrary
+            Theta.Float    -> float <$> arbitrary
+            Theta.Double   -> double <$> arbitrary
+            Theta.String   -> string . Text.pack <$> arbitrary
+            Theta.Date     -> date <$> genDate
+            Theta.Datetime -> datetime <$> genDatetime
 
           Theta.Array' item    -> Value t <$> genArray item
           Theta.Map' item      -> Value t <$> genMap item

--- a/theta/test/Test/Theta/Import.hs
+++ b/theta/test/Test/Theta/Import.hs
@@ -36,6 +36,7 @@ import           Theta.Import
 import qualified Theta.Metadata                as Metadata
 import qualified Theta.Name                    as Name
 import           Theta.Pretty                  (pretty)
+import qualified Theta.Primitive               as Theta
 import           Theta.Types                   (Module (..))
 import qualified Theta.Types                   as Theta
 import qualified Theta.Versions                as Versions
@@ -130,8 +131,8 @@ test_importModule = testGroup "importModule"
       case Theta.lookupName "test.Foo" combined1 of
         Left err                              -> assertFailure err
         Right Theta.Type { Theta.baseType }   -> case baseType of
-          Theta.Long' -> pure ()
-          Theta.Int'  ->
+          Theta.Primitive' Theta.Long -> pure ()
+          Theta.Primitive' Theta.Int  ->
             assertFailure "Wrong type shadowed: should be ‘Long’, not ‘Int’."
           invalid     ->
             assertFailure $ "Unexpected type in module—expected ‘Long’ but got ‘"
@@ -140,8 +141,8 @@ test_importModule = testGroup "importModule"
       case Theta.lookupName "test.Foo" combined2 of
         Left err                              -> assertFailure err
         Right Theta.Type { Theta.baseType }   -> case baseType of
-          Theta.Long' -> pure ()
-          Theta.Int'  ->
+          Theta.Primitive' Theta.Long -> pure ()
+          Theta.Primitive' Theta.Int  ->
             assertFailure "Wrong type shadowed: should be ‘Long’, not ‘Int’."
           invalid     ->
             assertFailure $ "Unexpected type in module—expected ‘Long’ but got ‘"

--- a/theta/test/Test/Theta/Parser.hs
+++ b/theta/test/Test/Theta/Parser.hs
@@ -22,6 +22,7 @@ import           Test.Tasty.HUnit
 import           Theta.Metadata          (Version)
 import qualified Theta.Metadata          as Metadata
 import           Theta.Parser
+import           Theta.Primitive         (Primitive (..))
 import           Theta.Types
 
 tests :: TestTree
@@ -112,66 +113,66 @@ test_metadataComments = testGroup "Metadata with comments"
 
 test_bool :: TestTree
 test_bool = testCase "Bool" $ do
-  parse' "1.0.0" bool "Bool" ?= BaseType' Bool'
-  parse' "1.0.0" atom "Bool" ?= BaseType' Bool'
+  parse' "1.0.0" primitive "Bool" ?= BaseType' (Primitive' Bool)
+  parse' "1.0.0" atom "Bool"      ?= BaseType' (Primitive' Bool)
 
 test_bytes :: TestTree
 test_bytes = testCase "Bytes" $ do
-  parse' "1.0.0" bytes "Bytes" ?= BaseType' Bytes'
-  parse' "1.0.0" atom "Bytes"  ?= BaseType' Bytes'
+  parse' "1.0.0" primitive "Bytes" ?= BaseType' (Primitive' Bytes)
+  parse' "1.0.0" atom "Bytes"      ?= BaseType' (Primitive' Bytes)
 
 test_int :: TestTree
 test_int = testCase "Int" $ do
-  parse' "1.0.0" int "Int"  ?= BaseType' Int'
-  parse' "1.0.0" atom "Int" ?= BaseType' Int'
+  parse' "1.0.0" primitive "Int" ?= BaseType' (Primitive' Int)
+  parse' "1.0.0" atom "Int"      ?= BaseType' (Primitive' Int)
 
 test_long :: TestTree
 test_long = testCase "Long" $ do
-  parse' "1.0.0" long  "Long" ?= BaseType' Long'
-  parse' "1.0.0" atom  "Long" ?= BaseType' Long'
+  parse' "1.0.0" primitive  "Long" ?= BaseType' (Primitive' Long)
+  parse' "1.0.0" atom  "Long"      ?= BaseType' (Primitive' Long)
 
 test_float :: TestTree
 test_float = testCase "Float" $ do
-  parse' "1.0.0" float  "Float" ?= BaseType' Float'
-  parse' "1.0.0" atom  "Float"  ?= BaseType' Float'
+  parse' "1.0.0" primitive  "Float" ?= BaseType' (Primitive' Float)
+  parse' "1.0.0" atom  "Float"      ?= BaseType' (Primitive' Float)
 
 test_double :: TestTree
 test_double = testCase "Double" $ do
-  parse' "1.0.0" double  "Double" ?= BaseType' Double'
-  parse' "1.0.0" atom  "Double"   ?= BaseType' Double'
+  parse' "1.0.0" primitive  "Double" ?= BaseType' (Primitive' Double)
+  parse' "1.0.0" atom  "Double"      ?= BaseType' (Primitive' Double)
 
 test_string :: TestTree
 test_string = testCase "String" $ do
-  parse' "1.0.0" str  "String"  ?= BaseType' String'
-  parse' "1.0.0" atom  "String" ?= BaseType' String'
+  parse' "1.0.0" primitive  "String" ?= BaseType' (Primitive' String)
+  parse' "1.0.0" atom  "String"      ?= BaseType' (Primitive' String)
 
 test_date :: TestTree
 test_date = testCase "Date" $ do
-  parse' "1.0.0" date "Date" ?= BaseType' Date'
-  parse' "1.0.0" atom "Date" ?= BaseType' Date'
+  parse' "1.0.0" primitive "Date" ?= BaseType' (Primitive' Date)
+  parse' "1.0.0" atom "Date"      ?= BaseType' (Primitive' Date)
 
 test_datetime :: TestTree
 test_datetime = testCase "Datetime" $ do
-  parse' "1.0.0" datetime "Datetime" ?= BaseType' Datetime'
-  parse' "1.0.0" atom "Datetime"     ?= BaseType' Datetime'
+  parse' "1.0.0" primitive "Datetime" ?= BaseType' (Primitive' Datetime)
+  parse' "1.0.0" atom "Datetime"      ?= BaseType' (Primitive' Datetime)
 
 
 -- * Containers
 
 test_array :: TestTree
 test_array = testCase "Array" $ do
-  parse' "1.0.0" array  "[String]" ?= BaseType' (Array' (BaseType' String'))
-  parse' "1.0.0" atom  "[String]"  ?= BaseType' (Array' (BaseType' String'))
+  parse' "1.0.0" array  "[String]" ?= BaseType' (Array' (BaseType' (Primitive' String)))
+  parse' "1.0.0" atom  "[String]"  ?= BaseType' (Array' (BaseType' (Primitive' String)))
 
   parse' "1.0.0" array  "[{Int}]" ?=
-    BaseType' (Array' (BaseType' (Map' (BaseType' Int'))))
+    BaseType' (Array' (BaseType' (Map' (BaseType' (Primitive' Int)))))
   parse' "1.0.0" atom  "[{Int}]"  ?=
-    BaseType' (Array' (BaseType' (Map' (BaseType' Int'))))
+    BaseType' (Array' (BaseType' (Map' (BaseType' (Primitive' Int)))))
 
   parse' "1.0.0" array  "[[Long]]" ?=
-    BaseType' (Array' (BaseType' (Array' (BaseType' Long'))))
+    BaseType' (Array' (BaseType' (Array' (BaseType' (Primitive' Long)))))
   parse' "1.0.0" atom  "[[Long]]"  ?=
-    BaseType' (Array' (BaseType' (Array' (BaseType' Long'))))
+    BaseType' (Array' (BaseType' (Array' (BaseType' (Primitive' Long)))))
 
   -- "Long" is a subset of "Longs"
   parse' "1.0.0" array "[foo.Longs]" ?=
@@ -181,18 +182,18 @@ test_array = testCase "Array" $ do
 
 test_map :: TestTree
 test_map = testCase "Map" $ do
-  parse' "1.0.0" map  "{String}"  ?= BaseType' (Map' (BaseType' String'))
-  parse' "1.0.0" atom  "{String}" ?= BaseType' (Map' (BaseType' String'))
+  parse' "1.0.0" map  "{String}"  ?= BaseType' (Map' (BaseType' (Primitive' String)))
+  parse' "1.0.0" atom  "{String}" ?= BaseType' (Map' (BaseType' (Primitive' String)))
 
   parse' "1.0.0" map  "{[Int]}"  ?=
-    BaseType' (Map' (BaseType' (Array' (BaseType' Int'))))
+    BaseType' (Map' (BaseType' (Array' (BaseType' (Primitive' Int)))))
   parse' "1.0.0" atom  "{[Int]}" ?=
-    BaseType' (Map' (BaseType' (Array' (BaseType' Int'))))
+    BaseType' (Map' (BaseType' (Array' (BaseType' (Primitive' Int)))))
 
   parse' "1.0.0" map  "{{Long}}"  ?=
-    BaseType' (Map' (BaseType' (Map' (BaseType' Long'))))
+    BaseType' (Map' (BaseType' (Map' (BaseType' (Primitive' Long)))))
   parse' "1.0.0" atom  "{{Long}}" ?=
-    BaseType' (Map' (BaseType' (Map' (BaseType' Long'))))
+    BaseType' (Map' (BaseType' (Map' (BaseType' (Primitive' Long)))))
 
   -- "Long" is a subset of "Longs"
   parse' "1.0.0" map "{foo.Longs}" ?=
@@ -202,18 +203,18 @@ test_map = testCase "Map" $ do
 
 test_optional :: TestTree
 test_optional = testCase "Optional" $ do
-  parse' "1.0.0" optional_  "String?"  ?= BaseType' (Optional' (BaseType' String'))
-  parse' "1.0.0" signature'  "String?" ?= BaseType' (Optional' (BaseType' String'))
+  parse' "1.0.0" optional_  "String?"  ?= BaseType' (Optional' (BaseType' (Primitive' String)))
+  parse' "1.0.0" signature'  "String?" ?= BaseType' (Optional' (BaseType' (Primitive' String)))
 
   parse' "1.0.0" optional_  "[String]?"  ?=
-    BaseType' (Optional' (BaseType' (Array' (BaseType' String'))))
+    BaseType' (Optional' (BaseType' (Array' (BaseType' (Primitive' String)))))
   parse' "1.0.0" signature'  "[String]?" ?=
-    BaseType' (Optional' (BaseType' (Array' (BaseType' String'))))
+    BaseType' (Optional' (BaseType' (Array' (BaseType' (Primitive' String)))))
 
   parse' "1.0.0" optional_  "[String?]?"  ?=
-    BaseType' (Optional' (BaseType' (Array' (BaseType' (Optional' (BaseType' String'))))))
+    BaseType' (Optional' (BaseType' (Array' (BaseType' (Optional' (BaseType' (Primitive' String)))))))
   parse' "1.0.0" signature'  "[String?]?" ?=
-    BaseType' (Optional' (BaseType' (Array' (BaseType' (Optional' (BaseType' String'))))))
+    BaseType' (Optional' (BaseType' (Array' (BaseType' (Optional' (BaseType' (Primitive' String)))))))
 
   -- "Long" is a subset of "Longs"
   parse' "1.0.0" optional_ "foo.Longs?" ?=
@@ -257,7 +258,7 @@ test_record = testGroup "Record"
                      \  foo : Int?\n\
                      \}\n"
           expected = BaseType' $ Record' "test.Foo" [field]
-          field    = Field "foo" Nothing $ BaseType' (Optional' (BaseType' Int'))
+          field    = Field "foo" Nothing $ BaseType' (Optional' (BaseType' (Primitive' Int)))
       parse' "1.0.0" definition oneField ?=
         Definition "test.Foo" Nothing expected
 
@@ -267,7 +268,7 @@ test_record = testGroup "Record"
                       \  bar : test2.Foo\n\
                       \}\n"
           expected  = BaseType' $ Record' "test.Foo" [field1, field2]
-          field1    = Field "foo" Nothing $ BaseType' (Optional' (BaseType' Int'))
+          field1    = Field "foo" Nothing $ BaseType' (Optional' (BaseType' (Primitive' Int)))
           field2    = Field "bar" Nothing $ BaseType' (Reference' "test2.Foo")
       parse' "1.0.0" definition twoFields ?=
         Definition "test.Foo" Nothing expected
@@ -278,8 +279,8 @@ test_record = testGroup "Record"
                       \  bar : Datetime\n\
                       \}\n"
           expected  = BaseType' $ Record' "test.Foo" [field1, field2]
-          field1    = Field "foo" Nothing $ BaseType' (Optional' (BaseType' Date'))
-          field2    = Field "bar" Nothing $ BaseType' Datetime'
+          field1    = Field "foo" Nothing $ BaseType' (Optional' (BaseType' (Primitive' Date)))
+          field2    = Field "bar" Nothing $ BaseType' (Primitive' Datetime)
       parse' "1.0.0" definition twoFields ?=
         Definition "test.Foo" Nothing expected
   ]
@@ -289,7 +290,7 @@ test_variant = testGroup "Variant"
   [ testCase "single case" $ do
       let withField = "type Foo = Foo { a : String }"
           expected  = BaseType' $ Variant' "test.Foo" [foo]
-          foo       = Case "test.Foo" Nothing [Field "a" Nothing $ BaseType' String']
+          foo       = Case "test.Foo" Nothing [Field "a" Nothing $ BaseType' (Primitive' String)]
       parse' "1.0.0" definition  withField ?=
         Definition "test.Foo" Nothing expected
 
@@ -302,7 +303,7 @@ test_variant = testGroup "Variant"
   , testCase "multiple cases" $ do
       let two      = "type Foo = Foo { a : String } | Bar {}"
           expected = BaseType' $ Variant' "test.Foo" [foo, bar]
-          foo      = Case "test.Foo" Nothing [Field "a" Nothing $ BaseType' String']
+          foo      = Case "test.Foo" Nothing [Field "a" Nothing $ BaseType' (Primitive' String)]
           bar      = Case "test.Bar" Nothing []
       parse' "1.0.0" definition  two ?=
         Definition "test.Foo" Nothing expected
@@ -310,10 +311,10 @@ test_variant = testGroup "Variant"
       let three    = "type Foo = Foo { a : String } \n\
                      \         | Bar {}\n      | Baz { a : Int? }\n"
           expected = BaseType' $ Variant' "test.Foo" [foo, bar, baz]
-          foo      = Case "test.Foo" Nothing [Field "a" Nothing $ BaseType' String']
+          foo      = Case "test.Foo" Nothing [Field "a" Nothing $ BaseType' (Primitive' String)]
           bar      = Case "test.Bar" Nothing []
           baz      = Case "test.Baz" Nothing [Field "a" Nothing $
-                                              BaseType' $ Optional' $ BaseType' Int']
+                                              BaseType' $ Optional' $ BaseType' (Primitive' Int)]
       parse' "1.0.0" definition  three ?=
         Definition "test.Foo" Nothing expected
 
@@ -329,7 +330,7 @@ test_variant = testGroup "Variant"
       let mix      = "type Foo = Bar | Baz { a : Int }"
           expected = BaseType' $ Variant' "test.Foo" [bar, baz]
           bar      = Case "test.Bar" Nothing []
-          baz      = Case "test.Baz" Nothing [Field "a" Nothing $ BaseType' Int']
+          baz      = Case "test.Baz" Nothing [Field "a" Nothing $ BaseType' (Primitive' Int)]
 
       parse' "1.0.0" (definition <* eof) mix ?=
         Definition "test.Foo" Nothing expected
@@ -429,7 +430,7 @@ test_docTypes = testGroup "docs on types"
               /// Foo is an Int!
               type Foo = Int
             |]
-          type_ = BaseType' (Newtype' "test.Foo" (BaseType' Int'))
+          type_ = BaseType' (Newtype' "test.Foo" (BaseType' (Primitive' Int)))
       parse' "1.0.0" (moduleBody "test") newtype_ ?=
         [DefinitionStatement
          (Definition "test.Foo" (Just $ Doc "Foo is an Int!") type_)]
@@ -441,7 +442,7 @@ test_docTypes = testGroup "docs on types"
         |]
       parse' "1.0.0" (moduleBody "test") alias ?=
         [DefinitionStatement
-         (Definition "test.Foo" (Just $ Doc "Foo is an Int!") (BaseType' Int'))]
+         (Definition "test.Foo" (Just $ Doc "Foo is an Int!") (BaseType' (Primitive' Int)))]
 
   , testCase "enums" $ do
       let enum = wrapModule [__i|
@@ -460,7 +461,7 @@ test_docTypes = testGroup "docs on types"
             type Foo = { bar : Int }
           |]
             type_ =
-              BaseType' (Record' "test.Foo" [Field "bar" Nothing (BaseType' Int')])
+              BaseType' (Record' "test.Foo" [Field "bar" Nothing (BaseType' (Primitive' Int))])
         parse' "1.0.0" (moduleBody "test") record ?=
           [DefinitionStatement (Definition "test.Foo" (Just $ Doc "Foo docs") type_)]
 
@@ -476,8 +477,8 @@ test_docTypes = testGroup "docs on types"
           |]
             type_ =
               BaseType' (Record' "test.Foo"
-                         [ Field "bar" (Just "Bar docs") (BaseType' Int')
-                         , Field "baz" (Just "baz\ndocs") (BaseType' String') ])
+                         [ Field "bar" (Just "Bar docs") (BaseType' (Primitive' Int))
+                         , Field "baz" (Just "baz\ndocs") (BaseType' (Primitive' String)) ])
         parse' "1.0.0" (moduleBody "test") record ?=
           [DefinitionStatement (Definition "test.Foo" Nothing type_)]
     ]
@@ -514,7 +515,7 @@ test_docTypes = testGroup "docs on types"
               BaseType' (Variant' "test.Foo"
                           [ Case "test.One" (Just "One docs") []
                           , Case "test.Two" (Just "Two docs")
-                            [Field "foo" (Just "foo docs") (BaseType' Int')]])
+                            [Field "foo" (Just "foo docs") (BaseType' (Primitive' Int))]])
         parse' "1.0.0" (moduleBody "test") variant ?=
           [DefinitionStatement (Definition "test.Foo" Nothing type_)]
     ]

--- a/theta/test/Test/Theta/Target/Avro/Types.hs
+++ b/theta/test/Test/Theta/Target/Avro/Types.hs
@@ -320,7 +320,7 @@ test_toSchema = testCase "toSchema" $ do
       docs     = Just
         [__i|
           Generated with Theta #{Theta.packageVersion'}
-          Type hash: 9bea6d3431cc3238ff611c832dfcd4d9
+          Type hash: 00c870b76a493aaac9709ea3b9968cc5
             |]
 
   case toSchema $ getDefinition "test.OneField" of

--- a/theta/test/Test/Theta/Target/Kotlin.hs
+++ b/theta/test/Test/Theta/Target/Kotlin.hs
@@ -82,7 +82,8 @@ test_toReference = testGroup "toReference"
       toReference variant   @?= [kotlin|FooVariant|]
       toReference newtype_  @?= [kotlin|FooNewtype|]
   ]
-  where wrap baseType = Theta.withModule' Theta.baseModule baseType
+  where wrap = Theta.withModule' (Theta.emptyModule "base" metadata)
+        metadata = Metadata "1.0.0" "1.0.0" "base"
 
 test_toRecord :: TestTree
 test_toRecord = testGroup "toRecord"

--- a/theta/test/Test/Theta/Target/Rust.hs
+++ b/theta/test/Test/Theta/Target/Rust.hs
@@ -112,7 +112,8 @@ test_toReference = testGroup "toReference"
       toReference variant   ??= "base::FooVariant"
       toReference newtype_  ??= "base::FooNewtype"
   ]
-  where wrap = Theta.withModule' Theta.baseModule
+  where wrap = Theta.withModule' (Theta.emptyModule "base" metadata)
+        metadata = Theta.Metadata "1.0.0" "1.0.0" "base"
 
 test_toEnum :: TestTree
 test_toEnum = testGroup "toEnum"
@@ -281,7 +282,9 @@ test_toRecord = testGroup "toRecord"
           }
         |]
   ]
-  where reference = Theta.withModule' Theta.baseModule . Theta.Reference'
+  where reference = Theta.withModule' baseModule . Theta.Reference'
+        baseModule = Theta.emptyModule "base" metadata
+        metadata = Theta.Metadata "1.0.0" "1.0.0" "base"
 
 test_toVariant :: TestTree
 test_toVariant = testGroup "toVariant"

--- a/theta/test/Test/Theta/Types.hs
+++ b/theta/test/Test/Theta/Types.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE NamedFieldPuns        #-}
 {-# LANGUAGE OverloadedLists       #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE QuasiQuotes           #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TemplateHaskell       #-}
 {-# LANGUAGE TypeApplications      #-}
 
@@ -23,7 +25,9 @@ import           Test.Tasty
 import           Test.Tasty.HUnit
 
 import           Theta.Pretty                  (pretty)
-import           Theta.Target.Haskell
+import           Theta.Primitive               (primitives)
+import qualified Theta.Primitive               as Theta
+import           Theta.Target.Haskell          (loadModule)
 import qualified Theta.Target.Haskell.HasTheta as HasTheta
 import           Theta.Types                   (moduleName, transitiveImports)
 import qualified Theta.Types                   as Theta
@@ -95,15 +99,16 @@ test_eq = testGroup "Eq instance"
         -- basicTypes list too
         checkType type_ = case Theta.baseType type_ of
           -- primitive types
-          Theta.Bool'        -> type_ @?= type_
-          Theta.Bytes'       -> type_ @?= type_
-          Theta.Int'         -> type_ @?= type_
-          Theta.Long'        -> type_ @?= type_
-          Theta.Float'       -> type_ @?= type_
-          Theta.Double'      -> type_ @?= type_
-          Theta.String'      -> type_ @?= type_
-          Theta.Date'        -> type_ @?= type_
-          Theta.Datetime'    -> type_ @?= type_
+          Theta.Primitive' p -> case p of
+            Theta.Bool     -> type_ @?= type_
+            Theta.Bytes    -> type_ @?= type_
+            Theta.Int      -> type_ @?= type_
+            Theta.Long     -> type_ @?= type_
+            Theta.Float    -> type_ @?= type_
+            Theta.Double   -> type_ @?= type_
+            Theta.String   -> type_ @?= type_
+            Theta.Date     -> type_ @?= type_
+            Theta.Datetime -> type_ @?= type_
 
           -- containers
           Theta.Array'{}     -> type_ @?= type_
@@ -192,77 +197,107 @@ test_HasDoc = testGroup "HasDoc"
 test_hashing :: TestTree
 test_hashing = testGroup "hashing"
   [ -- in case hashes change version-to-version
+    --
+    -- this is fine according to the contract spelled out in
+    -- Theta.Hash, but it shouldn't happen unless you intentionally
+    -- change the hashing logic
     testGroup "unchanged"
-    [ testCase "primitive" $ do
-        Theta.bool'     ?= "4919965a95bd3a2429452fd4a69276e4"
-        Theta.bytes'    ?= "0a54013f5513d0f2d6453c252b97f356"
-        Theta.int'      ?= "17ea9a080335a6f8f92212e20687d09b"
-        Theta.long'     ?= "1d9635869eeca793d715038fed6ad728"
-        Theta.float'    ?= "0e7bbb7af69b70f68553e17122313028"
-        Theta.double'   ?= "a5666b00d3697ec4ba60f56ebaff00b3"
-        Theta.string'   ?= "3f66b8f128b9b450ed674e5895366d2d"
-        Theta.date'     ?= "982300d27a39ddac604eb5b31f5681dd"
-        Theta.datetime' ?= "c3258332c6f795f29ed884f9399468ad"
+    [ testGroup "primitive" $
+        -- defining this as a function gives us a warning if we add
+        -- new primitive types but don't update this test case
+        let expectedPrimitive t = case t of
+              Theta.Bool     -> "368b9de4188c87e7afa1d7867dcf4413"
+              Theta.Bytes    -> "0fa7cf75524be7f38afd4c156a8806ca"
+              Theta.Int      -> "43d51ed7739b75a3636f33b75c599255"
+              Theta.Long     -> "bd1906da131060d558fff8de56142006"
+              Theta.Float    -> "f3e66d7cfcf8cec4e28182bfaee67c00"
+              Theta.Double   -> "d42662766a376211229617337bd427a9"
+              Theta.String   -> "4b041ed503e3481e6341363865732ab2"
+              Theta.Date     -> "f9796917d9806a980c089cae18f6d57e"
+              Theta.Datetime -> "e5158c40b7bc0dd7b50340fdb08e3c2b"
+            test name t =
+              testCase name (Theta.wrapPrimitive t ?= expectedPrimitive t)
+        in [ test (show t) t | t <- primitives ]
 
-    , testCase "container" $ do
-        Theta.array' Theta.bool' ?= "be04590193fe0b46274546386bbae04a"
-        Theta.array' Theta.int'  ?= "9e5c1459ccfdde08dd93f23cdf0c4656"
+    , testGroup "container"
+      [ testCase "[Bool]" $ Theta.array' Theta.bool' ?= "a923b66caa3b5848189d5f889979bd36"
+      , testCase "[Int]"  $ Theta.array' Theta.int'  ?= "10638db762caad1bc8d8a24c6a5f2561"
 
-        Theta.map' Theta.long'   ?= "2fd4b7df7008e79ecdaadfee4ed36056"
-        Theta.map' Theta.string' ?= "4748560da73c3354613dd674e7b42a05"
+      , testCase "{Long}"   $ Theta.map' Theta.long'   ?= "ae09ab852e0b160a795bf522d6cf2a97"
+      , testCase "{String}" $ Theta.map' Theta.string' ?= "2f68eeb4857f3642bc49a3928c57ca9e"
 
-        Theta.optional' Theta.bytes' ?= "fe8555ea03aa8ac9de9b74cda03313a3"
-        Theta.optional' Theta.date'  ?= "fb84e2ea1a4379adcb3ce3eb6cae3c6c"
+      , testCase "Bytes?" $ Theta.optional' Theta.bytes' ?= "1dbb7970dcf10823968dd187a01ba969"
+      , testCase "Date?"  $ Theta.optional' Theta.date'  ?= "e788ea9060022bad189298d2e253199d"
+      ]
 
     , testGroup "named types"
       [ testCase "enum" $ do
-          HasTheta.theta @TrickyEnum ?= "a5598bd1d8c1126f98add389ed96086c"
+          HasTheta.theta @TrickyEnum ?= "d82ce0b1c6f11f6f35538f04fccfbf50"
 
       , testCase "record" $ do
-          HasTheta.theta @Record   ?= "12830fe0301c2dbf8fbd09c85ed2bef8"
+          HasTheta.theta @Record   ?= "1a93bc566e8d4a6ab6c61e9942ff66f5"
 
       , testCase "variant" $ do
-          HasTheta.theta @Variant  ?= "d018a023a21f379ee6cefc2270e06760"
+          HasTheta.theta @Variant  ?= "6963fdd3e362d41b69dc873d829a3462"
 
-      , testCase "newtype" $ do
-          HasTheta.theta @Newtype  ?= "20f7cf73ddc12ea5aeb866dbcc147fa4"
-          HasTheta.theta @Newtype2 ?= "9a186dc3ed7f0a7206f313121ba5e98b"
+      , testGroup "newtype"
+        [ testCase "Newtype" $
+            HasTheta.theta @Newtype  ?= "f881fda8539d6269a4c8a69a019a6eca"
+        , testCase "Newtype2" $
+            HasTheta.theta @Newtype2 ?= "4056071b1f86b14d95f349ba02014633"
 
           -- from nested_types.theta
-          HasTheta.theta @Newtype_0 ?= "9afe3955179b3c12b134ffc8b708f83a"
-          HasTheta.theta @Newtype_1 ?= "b7dec420e20dc6ac129007a565aca39c"
+        , testCase "Newtype_0" $
+            HasTheta.theta @Newtype_0 ?= "05d345b5db4df5c3a158bc5309a1383f"
+        , testCase "Newtype_1" $
+            HasTheta.theta @Newtype_1 ?= "02c3ddf457aa85e993d10f89315d0f78"
+        ]
 
       , testCase "alias" $ do
-          HasTheta.theta @Alias     ?= "b7dec420e20dc6ac129007a565aca39c"
+          HasTheta.theta @Alias ?= "02c3ddf457aa85e993d10f89315d0f78"
       ]
 
     , testCase "recursive" $ do
-        HasTheta.theta @Recursive ?= "b49f702e7f64ff003622e4c476d81e3a"
+        HasTheta.theta @Recursive ?= "926649e7e828763c4333257b4f586af2"
 
-    , testCase "mutually recursive" $ do
-        HasTheta.theta @MutualA ?= "acbcf64168fe48a58e855ae625d610b4"
-        HasTheta.theta @MutualB ?= "1292adf5796a27df68a49d3bc049e190"
-        HasTheta.theta @Wrapper ?= "4479f3b3ab034cb491de22afe3527901"
+    , testGroup "mutually recursive"
+      [ testCase "MutualA" $
+          HasTheta.theta @MutualA ?= "5ed64a512c84ba695a337c0b0ac66ce6"
+      , testCase "MutualB" $
+          HasTheta.theta @MutualB ?= "4589f9047afc3114e5fc9b48e2e08524"
+      , testCase "Wrapper" $
+          HasTheta.theta @Wrapper ?= "e425e524f643bc1905a6ffc79242c5c7"
+      ]
 
-    , testCase "references" $ do
-        reference "named_types.Record"   ?= "12830fe0301c2dbf8fbd09c85ed2bef8"
-        reference "named_types.Variant"  ?= "d018a023a21f379ee6cefc2270e06760"
-        reference "named_types.Newtype"  ?= "20f7cf73ddc12ea5aeb866dbcc147fa4"
-        reference "named_types.Newtype2" ?= "9a186dc3ed7f0a7206f313121ba5e98b"
-        reference "named_types.Alias1"   ?= "12830fe0301c2dbf8fbd09c85ed2bef8"
+    , testGroup "references"
+      [ testCase "named_types.Record" $
+          reference "named_types.Record" ?= "1a93bc566e8d4a6ab6c61e9942ff66f5"
+      , testCase "named_types.Variant" $
+          reference "named_types.Variant" ?= "6963fdd3e362d41b69dc873d829a3462"
+      , testCase "named_types.Newtype" $
+          reference "named_types.Newtype" ?= "f881fda8539d6269a4c8a69a019a6eca"
+      , testCase "named_types.Newtype2" $
+          reference "named_types.Newtype2" ?= "4056071b1f86b14d95f349ba02014633"
+      , testCase "named_types.Alias1" $
+          reference "named_types.Alias1" ?= "1a93bc566e8d4a6ab6c61e9942ff66f5"
+      ]
     ]
 
   -- check that changes to structure of types changes hash
-  , testGroup "structure"
-    [ testCase "records" $
-        forM_ differentFields $ \ (description, fields') -> do
-          let message = "Hashes of fields and %s fields should be different."
-          assertBool (printf message description) $
-            Theta.hash (record "named_types.Example" fields) /=
-            Theta.hash (record "named_types.Example" fields')
+  , testGroup "structural changes"
+    [ testGroup "records"
+      [ testCase description $ do
+        let message = "Hashes of fields and %s fields should be different."
+        assertBool (printf message description) $
+          Theta.hash (record "named_types.Example" fields) /=
+          Theta.hash (record "named_types.Example" fields')
+      | (description, fields') <- differentFields
+      ]
 
-    , testCase "variants" $
-        Theta.hash variant @?= Theta.hash variant'
+    , testGroup "variant"
+      [ testCase "case order does not matter" $
+          Theta.hash variant @?= Theta.hash variant'
+      ]
     ]
   ]
   where Theta.Type { hash } ?= string = show hash @?= string

--- a/theta/test/data/python/bar_reference.mustache
+++ b/theta/test/data/python/bar_reference.mustache
@@ -1,6 +1,6 @@
 @dataclass
 class Bar:
-    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta {{version}}\\nType hash: f1f8d49e53501056214b7d466b09e73c","fields":[{"aliases":[],"name":"foo","type":{"aliases":[],"fields":[{"aliases":[],"name":"foo","type":"Foo"}],"name":"Foo","type":"record"}}],"name":"test.Bar","type":"record"}''')
+    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta {{version}}\\nType hash: b65eb4cc094eb0acb7c1c24fd402d36a","fields":[{"aliases":[],"name":"foo","type":{"aliases":[],"fields":[{"aliases":[],"name":"foo","type":"Foo"}],"name":"Foo","type":"record"}}],"name":"test.Bar","type":"record"}''')
 
     foo: 'Foo'
 

--- a/theta/test/data/python/empty_record.mustache
+++ b/theta/test/data/python/empty_record.mustache
@@ -1,6 +1,6 @@
 @dataclass
 class Empty:
-    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta {{version}}\\nType hash: 5d6c7cc16624e5f0ef7add5940e16636","fields":[],"name":"test.Empty","type":"record"}''')
+    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta {{version}}\\nType hash: 9195f61d4ba5740a8fb641de7f174566","fields":[],"name":"test.Empty","type":"record"}''')
 
 
 

--- a/theta/test/data/python/foo_reference.mustache
+++ b/theta/test/data/python/foo_reference.mustache
@@ -1,6 +1,6 @@
 @dataclass
 class Foo:
-    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta {{version}}\\nType hash: 04ca89441b4b70bfd004931441693fcb","fields":[{"aliases":[],"name":"foo","type":"Foo"}],"name":"test.Foo","type":"record"}''')
+    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta {{version}}\\nType hash: 326792c5b4b7acb338d8e5d7a1415ecf","fields":[{"aliases":[],"name":"foo","type":"Foo"}],"name":"test.Foo","type":"record"}''')
 
     foo: 'Foo'
 

--- a/theta/test/data/python/importing_reference.mustache
+++ b/theta/test/data/python/importing_reference.mustache
@@ -1,6 +1,6 @@
 @dataclass
 class Foo:
-    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta {{version}}\\nType hash: 59729a8cb95b8e1b6afeceef2a983cf4","fields":[{"aliases":[],"name":"importing","type":{"aliases":[],"fields":[],"name":"imported.Foo","type":"record"}}],"name":"test.Foo","type":"record"}''')
+    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta {{version}}\\nType hash: 19c0c8b592ae620fbe187c4507975805","fields":[{"aliases":[],"name":"importing","type":{"aliases":[],"fields":[],"name":"imported.Foo","type":"record"}}],"name":"test.Foo","type":"record"}''')
 
     importing: 'imported.Foo'
 

--- a/theta/test/data/python/newtype.mustache
+++ b/theta/test/data/python/newtype.mustache
@@ -13,7 +13,7 @@ Newtype = 'int'
 
 @dataclass
 class NewtypeRecord:
-    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta {{version}}\\nType hash: 38cea8f7c32e301f5430960b45092ebf","fields":[{"aliases":[],"name":"foo","type":"int"}],"name":"newtype.NewtypeRecord","type":"record"}''')
+    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta {{version}}\\nType hash: ba7a235e5b8ce0ecfe1458f23efef65f","fields":[{"aliases":[],"name":"foo","type":"int"}],"name":"newtype.NewtypeRecord","type":"record"}''')
 
     foo: 'Newtype'
 

--- a/theta/test/data/python/one_case.mustache
+++ b/theta/test/data/python/one_case.mustache
@@ -1,5 +1,5 @@
 class Variant(ABC):
-    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta {{version}}\\nType hash: a5c4c2ebac1fd93bd80d4ff0d02bc224","fields":[{"aliases":[],"name":"constructor","type":[{"aliases":[],"fields":[{"aliases":[],"name":"foo","type":"int"}],"name":"Case","type":"record"}]}],"name":"test.Variant","type":"record"}''')
+    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta {{version}}\\nType hash: c5a4fbbecf4095f13285be06437cbfb8","fields":[{"aliases":[],"name":"constructor","type":[{"aliases":[],"fields":[{"aliases":[],"name":"foo","type":"int"}],"name":"Case","type":"record"}]}],"name":"test.Variant","type":"record"}''')
 
     @staticmethod
     def decode_avro(decoder: avro.Decoder):

--- a/theta/test/data/python/one_case_importing.mustache
+++ b/theta/test/data/python/one_case_importing.mustache
@@ -1,5 +1,5 @@
 class Variant(ABC):
-    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta {{version}}\\nType hash: 0f3c222bbed476de54b4617234f058b5","fields":[{"aliases":[],"name":"constructor","type":[{"aliases":[],"fields":[{"aliases":[],"name":"importing","type":{"aliases":[],"fields":[],"name":"imported.Foo","type":"record"}}],"name":"Case","type":"record"}]}],"name":"test.Variant","type":"record"}''')
+    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta {{version}}\\nType hash: 97da494b4facc6ba36b096de1904ab9e","fields":[{"aliases":[],"name":"constructor","type":[{"aliases":[],"fields":[{"aliases":[],"name":"importing","type":{"aliases":[],"fields":[],"name":"imported.Foo","type":"record"}}],"name":"Case","type":"record"}]}],"name":"test.Variant","type":"record"}''')
 
     @staticmethod
     def decode_avro(decoder: avro.Decoder):

--- a/theta/test/data/python/one_field.mustache
+++ b/theta/test/data/python/one_field.mustache
@@ -1,6 +1,6 @@
 @dataclass
 class OneField:
-    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta {{version}}\\nType hash: eda14f6cd3eb32f2798dc03dbb9f4a4d","fields":[{"aliases":[],"name":"foo","type":"int"}],"name":"test.OneField","type":"record"}''')
+    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta {{version}}\\nType hash: 3310b8946f20a835ff10561cf0967f96","fields":[{"aliases":[],"name":"foo","type":"int"}],"name":"test.OneField","type":"record"}''')
 
     foo: 'int'
 

--- a/theta/test/data/python/two_cases.mustache
+++ b/theta/test/data/python/two_cases.mustache
@@ -1,5 +1,5 @@
 class Variant(ABC):
-    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta {{version}}\\nType hash: f9f5fa87870bc4fe62b567186a1c485d","fields":[{"aliases":[],"name":"constructor","type":[{"aliases":[],"fields":[{"aliases":[],"name":"foo","type":"int"}],"name":"One","type":"record"},{"aliases":[],"fields":[{"aliases":[],"name":"foo","type":"int"},{"aliases":[],"name":"bar","type":"string"}],"name":"Two","type":"record"}]}],"name":"test.Variant","type":"record"}''')
+    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta {{version}}\\nType hash: af0242d2de13c30251b0eb9b39aa236d","fields":[{"aliases":[],"name":"constructor","type":[{"aliases":[],"fields":[{"aliases":[],"name":"foo","type":"int"}],"name":"One","type":"record"},{"aliases":[],"fields":[{"aliases":[],"name":"foo","type":"int"},{"aliases":[],"name":"bar","type":"string"}],"name":"Two","type":"record"}]}],"name":"test.Variant","type":"record"}''')
 
     @staticmethod
     def decode_avro(decoder: avro.Decoder):

--- a/theta/test/data/python/two_fields.mustache
+++ b/theta/test/data/python/two_fields.mustache
@@ -1,6 +1,6 @@
 @dataclass
 class TwoFields:
-    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta {{version}}\\nType hash: 24395e1c611e39dc7b5aa9f87ec2292c","fields":[{"aliases":[],"name":"foo","type":"int"},{"aliases":[],"name":"bar","type":"string"}],"name":"test.TwoFields","type":"record"}''')
+    avro_schema: ClassVar[Dict[str, Any]] = json.loads('''{"aliases":[],"doc":"Generated with Theta {{version}}\\nType hash: 0a4212c30172aa12da90e4fb532764b7","fields":[{"aliases":[],"name":"foo","type":"int"},{"aliases":[],"name":"bar","type":"string"}],"name":"test.TwoFields","type":"record"}''')
 
     foo: 'int'
     bar: 'str'

--- a/theta/theta.cabal
+++ b/theta/theta.cabal
@@ -72,11 +72,13 @@ library
   hs-source-dirs:     src/
 
   exposed-modules:    Theta.Error
+                    , Theta.Hash
                     , Theta.Import
                     , Theta.Metadata
                     , Theta.Name
                     , Theta.Parser
                     , Theta.Pretty
+                    , Theta.Primitive
                     , Theta.Types
                     , Theta.Value
                     , Theta.Versions


### PR DESCRIPTION
This has made multiple parts of the code nicer to work with, especially when we go to add new primitive types. Two key advantages:

  1. I was already thinking of "primitive types" as a self-contained concept; this helps the code reflect that directly
  2. A number of places in the code now either update automatically when a new primitive type is added or will produce an incomplete pattern warning

This PR does not change any of the functionality in Theta, but it should make supporting additional primitive types much easier in the future.