### PR TITLE
Add Time primitive type

### DIFF
--- a/emacs/theta-mode.el
+++ b/emacs/theta-mode.el
@@ -36,7 +36,8 @@
     "String"
     "Date"
     "Datetime"
-    "UUID")
+    "UUID"
+    "Time")
 
   "Types that are built into Theta, indexed by the version of
   Theta they were introduced in.")

--- a/python/theta/avro.py
+++ b/python/theta/avro.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, time, timedelta
 import io
 import math
 import struct
@@ -121,6 +121,21 @@ class Encoder:
         Example: f81d4fae-7dec-11d0-a765-00a0c91e6bf6
         """
         self.string(str(uuid))
+
+    def time(self, t: time):
+        """
+        Write a Theta Time value to the output stream.
+
+        Times are encoded as a long with the number of microseconds
+        since midnight (time-micros in Avro).
+        """
+        micros = t.hour * 60 * 60 * 1000 * 1000
+        micros += t.minute * 60 * 1000 * 1000
+        micros += t.second * 1000 * 1000
+        micros += t.microsecond
+
+        self.integral(micros)
+
 
     # Containers
 
@@ -295,6 +310,21 @@ class Decoder:
         Raises an exception if the encoding does not conform to RFC 4122.
         """
         return UUID(self.string())
+
+    def time(self) -> time:
+        """
+        Decode a Time.
+
+        Times are encoded as a long with the number of microseconds
+        since midnight.
+        """
+        # Midnight on an arbitrary date. Python's time type does not
+        # support arithmetic, so using an arbitrary date is a
+        # workaround.
+        arbitrary = datetime(2000, 1, 1)
+        since_midnight = timedelta(microseconds=self.integral())
+
+        return (arbitrary + since_midnight).time()
 
     A = TypeVar("A")
 

--- a/test/cross-language/modules/primitives.theta
+++ b/test/cross-language/modules/primitives.theta
@@ -13,7 +13,8 @@ type Primitives = {
   string   : String,
   date     : Date,
   datetime : Datetime,
-  uuid : UUID
+  uuid : UUID,
+  time: Time
 }
 
 /// Each kind of container:

--- a/test/kotlin/modules/primitives.theta
+++ b/test/kotlin/modules/primitives.theta
@@ -14,7 +14,8 @@ type Primitives = {
   string   : String,
   date     : Date,
   datetime : Datetime,
-  uuid : UUID // language-version ≥ 1.1.0
+  uuid : UUID, // language-version ≥ 1.1.0
+  time : Time // language-version ≥ 1.1.0
 }
 
 // A record with the various kinds of containers Theta supports.

--- a/test/python/modules/primitives.theta
+++ b/test/python/modules/primitives.theta
@@ -14,7 +14,8 @@ type Primitives = {
   string   : String,
   date     : Date,
   datetime : Datetime,
-  uuid : UUID // language-version ≥ 1.1.0
+  uuid : UUID, // language-version ≥ 1.1.0
+  time : Time // language-version ≥ 1.1.0
 }
 
 // A record with the various kinds of containers Theta supports.

--- a/test/rust/modules/primitives.theta
+++ b/test/rust/modules/primitives.theta
@@ -14,7 +14,8 @@ type Primitives = {
   string   : String,
   date     : Date,
   datetime : Datetime,
-  uuid : UUID // language-version ≥ 1.1.0
+  uuid : UUID, // language-version ≥ 1.1.0
+  time : Time // language-version ≥ 1.1.0
 }
 
 // A record with the various kinds of containers Theta supports.

--- a/test/rust/src/lib.rs
+++ b/test/rust/src/lib.rs
@@ -12,8 +12,7 @@ pub mod enums;
 mod tests {
     use std::str::FromStr;
 
-    use chrono::naive::NaiveDate;
-    use chrono::{Date, DateTime, Utc};
+    use chrono::{Date, DateTime, NaiveDate, NaiveTime, Utc};
     use uuid::{Uuid};
 
     use std::collections::HashMap;
@@ -41,6 +40,7 @@ mod tests {
             date: Date::from_utc(NaiveDate::from_ymd(20, 12, 23), Utc),
             datetime: DateTime::from_utc(NaiveDate::from_ymd(10, 11, 12).and_hms(5, 0, 0), Utc),
             uuid: Uuid::from_str("f81d4fae-7dec-11d0-a765-00a0c91e6bf6").unwrap(),
+            time: NaiveTime::from_hms(12, 23, 10),
         };
         assert!(check_encoding(example));
     }
@@ -127,7 +127,8 @@ mod tests {
             string: "blarg".to_string(),
             date: Date::from_utc(NaiveDate::from_ymd(20, 12, 23), Utc),
             datetime: DateTime::from_utc(NaiveDate::from_ymd(10, 11, 12).and_hms(5, 0, 0), Utc),
-            uuid: Uuid::from_str("f81d4fae-7dec-11d0-a765-00a0c91e6bf6").unwrap()
+            uuid: Uuid::from_str("f81d4fae-7dec-11d0-a765-00a0c91e6bf6").unwrap(),
+            time: NaiveTime::from_hms(12, 23, 10),
         };
         let shadowing_record = shadowing::shadowing::Primitives {
             underlying: shadowed_record.clone(),

--- a/theta/src/Theta/Primitive.hs
+++ b/theta/src/Theta/Primitive.hs
@@ -29,7 +29,7 @@ import           Language.Haskell.TH.Syntax (Lift)
 
 import           Theta.Hash                 (Hash)
 import           Theta.Metadata             (Version)
-import           Theta.Name                 (Name, hashName)
+import           Theta.Name                 (Name (Name), hashName)
 import           Theta.Pretty               (Pretty, pretty)
 
 -- | Theta's primitive types.
@@ -60,6 +60,8 @@ data Primitive = Bool
                -- to [RFC 4122](https://www.ietf.org/rfc/rfc4122.txt)
                --
                -- Example: @f81d4fae-7dec-11d0-a765-00a0c91e6bf6@
+               | Time
+               -- ^ The time of day, starting at midnight.
  deriving stock (Eq, Show, Ord, Enum, Bounded, Lift)
 
 instance Pretty Primitive where pretty = primitiveKeyword
@@ -71,16 +73,7 @@ instance Pretty Primitive where pretty = primitiveKeyword
 -- @theta.primitive.Int@, @String@ becomes
 -- @theta.primitive.String@... etc.
 primitiveName :: Primitive -> Name
-primitiveName Bool     = "theta.primitive.Bool"
-primitiveName Bytes    = "theta.primitive.Bytes"
-primitiveName Int      = "theta.primitive.Int"
-primitiveName Long     = "theta.primitive.Long"
-primitiveName Float    = "theta.primitive.Float"
-primitiveName Double   = "theta.primitive.Double"
-primitiveName String   = "theta.primitive.String"
-primitiveName Date     = "theta.primitive.Date"
-primitiveName Datetime = "theta.primitive.Datetime"
-primitiveName UUID     = "theta.primitive.UUID"
+primitiveName = Name "theta.primitive" . primitiveKeyword
 
 -- | The canonical keyword for each primitive type.
 --
@@ -106,6 +99,7 @@ definedIn String   = "1.0.0"
 definedIn Date     = "1.0.0"
 definedIn Datetime = "1.0.0"
 definedIn UUID     = "1.1.0"
+definedIn Time     = "1.1.0"
 
 -- | Every single primitive type supported by Theta.
 primitives :: [Primitive]

--- a/theta/src/Theta/Target/Avro/Types.hs
+++ b/theta/src/Theta/Target/Avro/Types.hs
@@ -337,6 +337,8 @@ primitiveType contextAvroVersion = \case
 
   Theta.UUID -> Avro.String (Just Avro.UUID)
 
+  Theta.Time -> Avro.Long (Just Avro.TimeMicros)
+
 -- | Transforms any Theta expression into a fragment of an Avro
 -- schema. This schema might not stand alone—for example, it could
 -- just be a reference to a named or built-in Avro type.

--- a/theta/src/Theta/Target/Avro/Values.hs
+++ b/theta/src/Theta/Target/Avro/Values.hs
@@ -99,6 +99,7 @@ toAvro value@Value { type_ } = do
             (ReadSchema.Int _, Date d)        -> Avro.Int schema $ fromDay d
             (ReadSchema.Long _ _, Datetime t) -> Avro.Long schema $ fromUTCTime t
             (ReadSchema.String _, UUID u)     -> Avro.String schema $ UUID.toText u
+            (ReadSchema.Long _ _, Time t)     -> Avro.Long schema $ fromDayTime t
 
             (_, _) -> error $ "Mismatch between the type_ and value of a Value. \
                               \This is a bug in the Theta implementation.\n"
@@ -236,6 +237,7 @@ fromAvro type_@Theta.Type { baseType, module_ } avro = do
             (Theta.UUID, Avro.String _ s)   -> case UUID.fromText s of
               Just uuid -> wrapPrimitive $ UUID uuid
               Nothing   -> throw $ InvalidUUID s
+            (Theta.Time, Avro.Long _ l)     -> wrapPrimitive $ Time $ toDayTime l
             (_, got)                        -> throw $ TypeMismatch type_ got
 
           -- containers
@@ -425,6 +427,20 @@ fromUTCTime (Time.UTCTime day inDay) = fromInteger $ days * dayLength + micros
 
         micros = Time.diffTimeToPicoseconds inDay `div` 1e6
 {-# INLINE fromUTCTime #-}
+
+-- | Convert an Avro-style microsecond-precision time to a 'DayTime'.
+--
+-- The Avro format for time is a long storing the number of
+-- microseconds from midnight.
+toDayTime :: Int64 -> DayTime
+toDayTime (fromIntegral -> microseconds) =
+  DayTime $ picosecondsToDiffTime $ microseconds * 1e6
+
+-- | Convert a 'DayTime' to a 'Long' containing the number of
+-- microseconds since midnight.
+fromDayTime :: DayTime -> Int64
+fromDayTime (DayTime time) =
+  fromInteger $ Time.diffTimeToPicoseconds time `div` 1e6
 
 
 -- | Convert an Avro name to the corresponding Theta name.

--- a/theta/src/Theta/Target/Haskell.hs
+++ b/theta/src/Theta/Target/Haskell.hs
@@ -264,6 +264,7 @@ generateThetaExp type_ = case Theta.baseType type_ of
     Primitive.Date     -> [e| Theta.date' |]
     Primitive.Datetime -> [e| Theta.datetime' |]
     Primitive.UUID     -> [e| Theta.uuid' |]
+    Primitive.Time     -> [e| Theta.time' |]
 
   Theta.Array' type_        -> [e| Theta.array' $(generateThetaExp type_) |]
   Theta.Map' type_          -> [e| Theta.map' $(generateThetaExp type_) |]
@@ -1188,6 +1189,7 @@ generateType type_ = case Theta.baseType type_ of
     Primitive.Date     -> [t| Day |]
     Primitive.Datetime -> [t| UTCTime |]
     Primitive.UUID     -> [t| UUID |]
+    Primitive.Time     -> [t| Theta.DayTime |]
 
   Theta.Array' items    -> [t| [$(generateType items)] |]
   Theta.Map' values     -> [t| HashMap Text $(generateType values) |]

--- a/theta/src/Theta/Target/Haskell/Conversion.hs
+++ b/theta/src/Theta/Target/Haskell/Conversion.hs
@@ -67,6 +67,7 @@ import qualified Theta.Target.Avro.Values      as Values
 
 import           Theta.Target.Haskell.HasTheta (HasTheta (theta))
 import qualified Theta.Target.Haskell.HasTheta as HasTheta
+import Theta.Value (DayTime)
 
 -- * Conversion classes
 
@@ -276,6 +277,18 @@ instance FromTheta UUID where
     case UUID.fromText str of
       Just uuid -> pure uuid
       Nothing   -> fail (printf "Invalid UUID format in string:\n%s" str)
+
+instance ToTheta DayTime where
+  toTheta = Theta.time
+
+  avroEncoding = avroEncoding . Values.fromDayTime
+
+instance FromTheta DayTime where
+  fromTheta' Theta.Value { Theta.type_, Theta.value } = case value of
+    Theta.Primitive (Theta.Time time) -> pure time
+    _                                 -> mismatch Theta.time' type_
+
+  avroDecoding = Values.toDayTime <$> DecodeRaw.decodeRaw @Int64
 
 instance ToTheta a => ToTheta [a] where
   toTheta values = Theta.Value

--- a/theta/src/Theta/Target/Haskell/HasTheta.hs
+++ b/theta/src/Theta/Target/Haskell/HasTheta.hs
@@ -19,6 +19,7 @@ import           Data.Time.Clock      (UTCTime)
 import           Data.UUID            (UUID)
 
 import qualified Theta.Types          as Theta
+import           Theta.Value          (DayTime)
 
 -- | A class for Haskell types that correspond to a Theta type. Types
 -- generated via Template Haskell will automatically have an instance
@@ -61,6 +62,9 @@ instance HasTheta UTCTime where
 
 instance HasTheta UUID where
   theta = Theta.uuid'
+
+instance HasTheta DayTime where
+  theta = Theta.time'
 
 instance HasTheta a => HasTheta [a] where
   theta = Theta.array' $ theta @a

--- a/theta/src/Theta/Target/Kotlin.hs
+++ b/theta/src/Theta/Target/Kotlin.hs
@@ -55,6 +55,7 @@ toModule prefix Theta.Module {..} =
 
     import java.time.LocalDate
     import java.time.LocalDateTime
+    import java.time.LocalTime
 
     import java.util.UUID
 
@@ -176,16 +177,17 @@ toReference Theta.Type { Theta.baseType } = case baseType of
 
   -- primitive types
   Theta.Primitive' t -> case t of
-    Theta.Bool     -> [kotlin|Boolean|]
-    Theta.Bytes    -> [kotlin|ByteArray|]
-    Theta.Int      -> [kotlin|Int|]
-    Theta.Long     -> [kotlin|Long|]
-    Theta.Float    -> [kotlin|Float|]
-    Theta.Double   -> [kotlin|Double|]
-    Theta.String   -> [kotlin|String|]
-    Theta.Date     -> [kotlin|LocalDate|]
-    Theta.Datetime -> [kotlin|LocalDateTime|]
-    Theta.UUID     -> [kotlin|UUID|]
+    Theta.Bool     -> "Boolean"
+    Theta.Bytes    -> "ByteArray"
+    Theta.Int      -> "Int"
+    Theta.Long     -> "Long"
+    Theta.Float    -> "Float"
+    Theta.Double   -> "Double"
+    Theta.String   -> "String"
+    Theta.Date     -> "LocalDate"
+    Theta.Datetime -> "LocalDateTime"
+    Theta.UUID     -> "UUID"
+    Theta.Time     -> "LocalTime"
 
   -- containers
   Theta.Array' a        -> let items = toReference a in [kotlin|Array<$items>|]

--- a/theta/src/Theta/Target/Python.hs
+++ b/theta/src/Theta/Target/Python.hs
@@ -66,7 +66,7 @@ toModule Theta.Module {..} prefix = do
   pure [python|
     from abc import ABC
     from dataclasses import dataclass
-    from datetime import date, datetime
+    from datetime import date, datetime, time
     from enum import Enum
     import json
     from typing import Any, ClassVar, Dict, Iterator, List, Mapping, Optional
@@ -101,6 +101,7 @@ primitive Theta.String   = "str"
 primitive Theta.Date     = "date"
 primitive Theta.Datetime = "datetime"
 primitive Theta.UUID     = "UUID"
+primitive Theta.Time     = "time"
 
 -- | Return a Python snippet that /refers/ to the given Theta"a"
 --
@@ -477,6 +478,7 @@ encodingFunction Theta.Type { Theta.baseType, Theta.module_ } = case baseType of
     Theta.Date     -> "encoder.date"
     Theta.Datetime -> "encoder.datetime"
     Theta.UUID     -> "encoder.uuid"
+    Theta.Time     -> "encoder.time"
 
   -- Containers
   Theta.Array' type_    -> do
@@ -541,6 +543,7 @@ decodingFunction prefix currentModule Theta.Type { Theta.baseType, Theta.module_
       Theta.Date     -> "decoder.date()"
       Theta.Datetime -> "decoder.datetime()"
       Theta.UUID     -> "decoder.uuid()"
+      Theta.Time     -> "decoder.time()"
 
     -- Containers
     Theta.Array' type_ -> do

--- a/theta/src/Theta/Target/Rust.hs
+++ b/theta/src/Theta/Target/Rust.hs
@@ -95,7 +95,7 @@ toModule Theta.Module { Theta.types } = definitionLines $ imports : typeDefiniti
   where typeDefinitions = toDefinition <$> Map.elems types
 
         imports = [rust|
-          use chrono::{Date, DateTime, Utc};
+          use chrono::{Date, DateTime, NaiveTime, Utc};
           use std::collections::HashMap;
           use theta::avro::{FromAvro, ToAvro};
           use nom::{IResult, Err, error::{context, ErrorKind}};
@@ -177,6 +177,7 @@ typeIdentifier Theta.Type { Theta.baseType } = case baseType of
     Theta.Date     -> ["Date"]
     Theta.Datetime -> ["DateTime"]
     Theta.UUID     -> ["Uuid"]
+    Theta.Time     -> ["NaiveTime"]
 
   -- containers
   Theta.Array' _        -> ["Vec"]

--- a/theta/src/Theta/Types.hs
+++ b/theta/src/Theta/Types.hs
@@ -505,6 +505,9 @@ datetime' = wrapPrimitive Datetime
 uuid' :: Type
 uuid' = wrapPrimitive UUID
 
+time' :: Type
+time' = wrapPrimitive Time
+
 array' :: Type -> Type
 array' t = Type
   { baseType = Array' t

--- a/theta/test/Test/Theta/Target/Kotlin.hs
+++ b/theta/test/Test/Theta/Target/Kotlin.hs
@@ -155,6 +155,7 @@ test_toModule = testGroup "toModule"
 
         import java.time.LocalDate
         import java.time.LocalDateTime
+        import java.time.LocalTime
 
         import java.util.UUID
 
@@ -175,6 +176,7 @@ test_toModule = testGroup "toModule"
 
         import java.time.LocalDate
         import java.time.LocalDateTime
+        import java.time.LocalTime
 
         import java.util.UUID
 
@@ -193,6 +195,7 @@ test_toModule = testGroup "toModule"
 
         import java.time.LocalDate
         import java.time.LocalDateTime
+        import java.time.LocalTime
 
         import java.util.UUID
 

--- a/theta/test/Test/Theta/Types.hs
+++ b/theta/test/Test/Theta/Types.hs
@@ -80,6 +80,7 @@ test_eq = testGroup "Eq instance"
           , Theta.date'
           , Theta.datetime'
           , Theta.uuid'
+          , Theta.time'
 
           , Theta.array' Theta.int'
           , Theta.map' Theta.int'
@@ -113,6 +114,7 @@ test_eq = testGroup "Eq instance"
             Theta.Date     -> type_ @?= type_
             Theta.Datetime -> type_ @?= type_
             Theta.UUID     -> type_ @?= type_
+            Theta.Time     -> type_ @?= type_
 
           -- containers
           Theta.Array'{}     -> type_ @?= type_
@@ -244,6 +246,7 @@ test_hashing = testGroup "hashing"
               Theta.Date     -> "f9796917d9806a980c089cae18f6d57e"
               Theta.Datetime -> "e5158c40b7bc0dd7b50340fdb08e3c2b"
               Theta.UUID     -> "d2e4edd151c5d24637c63111311b13d1"
+              Theta.Time     -> "d25ae4f8007c356e61dcd841309ca82e"
             test name t =
               testCase name (Theta.wrapPrimitive t ?= expectedPrimitive t)
         in [ test (show t) t | t <- primitives ]

--- a/theta/test/data/python/importing_foo.mustache
+++ b/theta/test/data/python/importing_foo.mustache
@@ -1,6 +1,6 @@
 from abc import ABC
 from dataclasses import dataclass
-from datetime import date, datetime
+from datetime import date, datetime, time
 from enum import Enum
 import json
 from typing import Any, ClassVar, Dict, Iterator, List, Mapping, Optional

--- a/theta/test/data/python/importing_foo_qualified.mustache
+++ b/theta/test/data/python/importing_foo_qualified.mustache
@@ -1,6 +1,6 @@
 from abc import ABC
 from dataclasses import dataclass
-from datetime import date, datetime
+from datetime import date, datetime, time
 from enum import Enum
 import json
 from typing import Any, ClassVar, Dict, Iterator, List, Mapping, Optional

--- a/theta/test/data/python/newtype.mustache
+++ b/theta/test/data/python/newtype.mustache
@@ -1,6 +1,6 @@
 from abc import ABC
 from dataclasses import dataclass
-from datetime import date, datetime
+from datetime import date, datetime, time
 from enum import Enum
 import json
 from typing import Any, ClassVar, Dict, Iterator, List, Mapping, Optional

--- a/theta/test/data/rust/enums.rs
+++ b/theta/test/data/rust/enums.rs
@@ -1,4 +1,4 @@
-use chrono::{Date, DateTime, Utc};
+use chrono::{Date, DateTime, NaiveTime, Utc};
 use std::collections::HashMap;
 use theta::avro::{FromAvro, ToAvro};
 use nom::{IResult, Err, error::{context, ErrorKind}};

--- a/theta/test/data/rust/newtype.rs
+++ b/theta/test/data/rust/newtype.rs
@@ -1,4 +1,4 @@
-use chrono::{Date, DateTime, Utc};
+use chrono::{Date, DateTime, NaiveTime, Utc};
 use std::collections::HashMap;
 use theta::avro::{FromAvro, ToAvro};
 use nom::{IResult, Err, error::{context, ErrorKind}};

--- a/theta/test/data/rust/recursive.rs
+++ b/theta/test/data/rust/recursive.rs
@@ -1,4 +1,4 @@
-use chrono::{Date, DateTime, Utc};
+use chrono::{Date, DateTime, NaiveTime, Utc};
 use std::collections::HashMap;
 use theta::avro::{FromAvro, ToAvro};
 use nom::{IResult, Err, error::{context, ErrorKind}};

--- a/theta/test/data/rust/single_file.rs
+++ b/theta/test/data/rust/single_file.rs
@@ -5,7 +5,7 @@ pub mod newtype {
     use super::newtype;
     use super::recursive;
 
-    use chrono::{Date, DateTime, Utc};
+    use chrono::{Date, DateTime, NaiveTime, Utc};
     use std::collections::HashMap;
     use theta::avro::{FromAvro, ToAvro};
     use nom::{IResult, Err, error::{context, ErrorKind}};
@@ -54,7 +54,7 @@ pub mod recursive {
     use super::newtype;
     use super::recursive;
 
-    use chrono::{Date, DateTime, Utc};
+    use chrono::{Date, DateTime, NaiveTime, Utc};
     use std::collections::HashMap;
     use theta::avro::{FromAvro, ToAvro};
     use nom::{IResult, Err, error::{context, ErrorKind}};


### PR DESCRIPTION
This PR adds a `Time` primitive type (given `language-version` ≥ 1.1.0). The `Time` type represents a time of day (ie time since midnight) with no date or timezone. It compiles to:

  * `{ "type" : "long", "logicalType" : "time-micros" }` in Avro
  * `DayTime` in Haskell: a newtype over [`DiffTime`][DiffTime] defined in `Theta.Value`[^haskell]
  * [`datetime.time`][python-time] in Python
  * [`NaiveTime`][rust-time] from [chrono] in Rust
  * [`LocalTime`][kotlin-time] in Kotlin

[^haskell]: Haskell's [`time`][haskell-time] library does not have a dedicated "time of day" type, but I want to reserve `DiffTime` for adding a `Duration` primitive type, so I wrapped `DiffTime` in a newtype.

I will likely implement a `LocalDateTime` soon, corresponding to Avro's [`local-timestamp-micros`][avro-local-datetime] logical type. I also want to implement a `Duration` type, but since that's [encoded in Avro][avro-duration] as a fixed-size type, it'll need some support work first.

I currently do not plan to implement Avro's millisecond-precision variations on `time`, `timestamp` and `local-timestamp`, but that might change if I have a good idea about how to do that. (Maybe with annotations or something?)

[DiffTime]: https://hackage.haskell.org/package/time/docs/Data-Time-Clock.html#t:DiffTime

[haskell-time]: https://hackage.haskell.org/package/time

[python-time]: https://docs.python.org/3/library/datetime.html#datetime.time

[rust-time]: https://docs.rs/chrono/0.4.0/chrono/naive/struct.NaiveTime.html

[kotlin-time]: https://docs.oracle.com/javase/8/docs/api/java/time/LocalTime.html

[avro-local-datetime]: https://avro.apache.org/docs/current/spec.html#Local+timestamp+%28microsecond+precision%29

[avro-duration]: https://avro.apache.org/docs/current/spec.html#Duration