### PR TITLE
Fix Time implementation

### DIFF
--- a/theta/src/Theta/Target/Haskell.hs
+++ b/theta/src/Theta/Target/Haskell.hs
@@ -80,8 +80,7 @@ import qualified Data.Set                        as Set
 import           Data.Tagged                     (Tagged (..))
 import           Data.Text                       (Text)
 import qualified Data.Text                       as Text
-import           Data.Time.Calendar              (Day)
-import           Data.Time.Clock                 (UTCTime)
+import           Data.Time                       (Day, TimeOfDay, UTCTime)
 import           Data.UUID                       (UUID)
 import           Data.Vector                     ((!))
 import qualified Data.Vector                     as Vector
@@ -1189,7 +1188,7 @@ generateType type_ = case Theta.baseType type_ of
     Primitive.Date     -> [t| Day |]
     Primitive.Datetime -> [t| UTCTime |]
     Primitive.UUID     -> [t| UUID |]
-    Primitive.Time     -> [t| Theta.DayTime |]
+    Primitive.Time     -> [t| TimeOfDay |]
 
   Theta.Array' items    -> [t| [$(generateType items)] |]
   Theta.Map' values     -> [t| HashMap Text $(generateType values) |]

--- a/theta/src/Theta/Target/Haskell/Conversion.hs
+++ b/theta/src/Theta/Target/Haskell/Conversion.hs
@@ -42,8 +42,7 @@ import qualified Data.HashMap.Strict           as HashMap
 import           Data.Int                      (Int32, Int64)
 import           Data.Text                     (Text)
 import qualified Data.Text                     as Text
-import           Data.Time.Calendar            (Day)
-import           Data.Time.Clock               (UTCTime)
+import           Data.Time                     (Day, TimeOfDay, UTCTime)
 import           Data.UUID                     (UUID)
 import qualified Data.UUID                     as UUID
 import qualified Data.Vector                   as Vector
@@ -67,7 +66,6 @@ import qualified Theta.Target.Avro.Values      as Values
 
 import           Theta.Target.Haskell.HasTheta (HasTheta (theta))
 import qualified Theta.Target.Haskell.HasTheta as HasTheta
-import Theta.Value (DayTime)
 
 -- * Conversion classes
 
@@ -278,17 +276,17 @@ instance FromTheta UUID where
       Just uuid -> pure uuid
       Nothing   -> fail (printf "Invalid UUID format in string:\n%s" str)
 
-instance ToTheta DayTime where
+instance ToTheta TimeOfDay where
   toTheta = Theta.time
 
-  avroEncoding = avroEncoding . Values.fromDayTime
+  avroEncoding = avroEncoding . Values.fromTimeOfDay
 
-instance FromTheta DayTime where
+instance FromTheta TimeOfDay where
   fromTheta' Theta.Value { Theta.type_, Theta.value } = case value of
     Theta.Primitive (Theta.Time time) -> pure time
     _                                 -> mismatch Theta.time' type_
 
-  avroDecoding = Values.toDayTime <$> DecodeRaw.decodeRaw @Int64
+  avroDecoding = Values.toTimeOfDay <$> DecodeRaw.decodeRaw @Int64
 
 instance ToTheta a => ToTheta [a] where
   toTheta values = Theta.Value

--- a/theta/src/Theta/Target/Haskell/HasTheta.hs
+++ b/theta/src/Theta/Target/Haskell/HasTheta.hs
@@ -14,12 +14,10 @@ import           Data.ByteString.Lazy (ByteString)
 import           Data.HashMap.Strict  (HashMap)
 import           Data.Int             (Int32, Int64)
 import           Data.Text            (Text)
-import           Data.Time.Calendar   (Day)
-import           Data.Time.Clock      (UTCTime)
+import           Data.Time            (Day, TimeOfDay, UTCTime)
 import           Data.UUID            (UUID)
 
 import qualified Theta.Types          as Theta
-import           Theta.Value          (DayTime)
 
 -- | A class for Haskell types that correspond to a Theta type. Types
 -- generated via Template Haskell will automatically have an instance
@@ -63,7 +61,7 @@ instance HasTheta UTCTime where
 instance HasTheta UUID where
   theta = Theta.uuid'
 
-instance HasTheta DayTime where
+instance HasTheta TimeOfDay where
   theta = Theta.time'
 
 instance HasTheta a => HasTheta [a] where

--- a/theta/test/Test/Assertions.hs
+++ b/theta/test/Test/Assertions.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ViewPatterns      #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
 -- | Helper functions for testing: assertions/etc with human-readable
 -- diff outputs.
 module Test.Assertions where
@@ -11,8 +13,9 @@ import qualified Data.Algorithm.Diff           as Diff
 import qualified Data.Algorithm.DiffOutput     as Diff
 import           Data.Text                     (Text)
 import qualified Data.Text                     as Text
-import           Data.TreeDiff                 (Edit, EditExpr, Expr, GToExpr,
-                                                exprDiff, genericToExpr,
+import           Data.TreeDiff                 (Edit, EditExpr, Expr (App), GToExpr,
+                                                ToExpr (..), exprDiff,
+                                                genericToExpr,
                                                 ppEditExprCompact, ppExpr)
 import           Data.TreeDiff.Pretty          (Pretty (..), ppEditExpr)
 
@@ -25,6 +28,7 @@ import           Prettyprinter.Render.Terminal (AnsiStyle,
 
 import qualified Test.Tasty.HUnit              as HUnit
 
+import           Data.Time                     (TimeOfDay)
 import           Theta.Target.LanguageQuoter   (Interpolable, toText)
 
 -- * Human-Readable Diffs
@@ -117,3 +121,8 @@ humanDiff a b = Text.pack $ Diff.ppDiff (toString <$> diff a b)
 a ?= b = when (normalize a /= normalize b) $ do
   HUnit.assertFailure (Text.unpack $ humanDiff a b)
   where normalize = Text.strip . toText
+
+-- ** Orphan Instances
+
+instance ToExpr TimeOfDay where
+  toExpr t = App "TimeOfDay" [toExpr $ show t]

--- a/theta/test/Test/Theta/Target/Avro/Process.hs
+++ b/theta/test/Test/Theta/Target/Avro/Process.hs
@@ -19,11 +19,11 @@ import           Test.Tasty.QuickCheck           (forAll, listOf, testProperty)
 import           Test.Assertions                 (assertDiff)
 
 import qualified Streamly.Prelude                as Streamly
+
 import           Theta.Pretty                    (Pretty (pretty))
 import           Theta.Target.Avro.Process       (run, stream)
 import           Theta.Target.Haskell            (loadModule)
 import           Theta.Target.Haskell.Conversion (genTheta)
-
 
 
 loadModule "test/data/modules" "primitives"

--- a/theta/test/Test/Theta/Target/Haskell.hs
+++ b/theta/test/Test/Theta/Target/Haskell.hs
@@ -67,7 +67,7 @@ test_primitives = testGroup "primitives"
   , testCase "fromAvro ∘ toAvro = id" $ do
       Avro.decodeValue (Avro.encodeValue primitives) @?= Right primitives
   ]
-  where primitives = Primitives True "blarg" 37 42 1.2 7.4 "foo" today now uuid
+  where primitives = Primitives True "blarg" 37 42 1.2 7.4 "foo" today now uuid time
         expected = Theta.Record
           [ Theta.boolean True
           , Theta.bytes "blarg"
@@ -79,10 +79,12 @@ test_primitives = testGroup "primitives"
           , Theta.date today
           , Theta.datetime now
           , Theta.uuid uuid
+          , Theta.time time
           ]
 
         today = read "2019-02-11"
         now   = read "2019-02-11 14:23:12 UTC"
+        time  = read "14:23:12"
         uuid  = fromMaybe (error "Invalid UUID literal.") $
           UUID.fromText "f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
 

--- a/theta/test/data/modules/primitives.theta
+++ b/theta/test/data/modules/primitives.theta
@@ -14,7 +14,8 @@ type Primitives = {
   string   : String,
   date     : Date,
   datetime : Datetime,
-  uuid : UUID
+  uuid : UUID,
+  time : Time
 }
 
 type Containers = {


### PR DESCRIPTION
After merging #56, I found that [time] *did* have a local-time type called [`TimeOfDay`][time-of-day], so this PR replaces my `DayTime` newtype with that instead.

I also forgot to add the `Time` type to `test/data/modules/primitives.theta`, which hid a couple of other bugs. Now the test module is updated and the bugs are fixed.