### PR TITLE
Add LocalDatetime type

### DIFF
--- a/emacs/theta-mode.el
+++ b/emacs/theta-mode.el
@@ -37,7 +37,8 @@
     "Date"
     "Datetime"
     "UUID"
-    "Time")
+    "Time"
+    "LocalDatetime")
 
   "Types that are built into Theta, indexed by the version of
   Theta they were introduced in.")

--- a/test/cross-language/modules/primitives.theta
+++ b/test/cross-language/modules/primitives.theta
@@ -14,7 +14,8 @@ type Primitives = {
   date     : Date,
   datetime : Datetime,
   uuid : UUID,
-  time: Time
+  time: Time,
+  local_datetime: LocalDatetime
 }
 
 /// Each kind of container:

--- a/test/kotlin/modules/primitives.theta
+++ b/test/kotlin/modules/primitives.theta
@@ -15,7 +15,8 @@ type Primitives = {
   date     : Date,
   datetime : Datetime,
   uuid : UUID, // language-version ≥ 1.1.0
-  time : Time // language-version ≥ 1.1.0
+  time : Time, // language-version ≥ 1.1.0
+  local_datetime : LocalDatetime // language-version ≥ 1.1.0
 }
 
 // A record with the various kinds of containers Theta supports.

--- a/test/python/modules/primitives.theta
+++ b/test/python/modules/primitives.theta
@@ -15,7 +15,8 @@ type Primitives = {
   date     : Date,
   datetime : Datetime,
   uuid : UUID, // language-version ≥ 1.1.0
-  time : Time // language-version ≥ 1.1.0
+  time : Time, // language-version ≥ 1.1.0
+  local_datetime : LocalDatetime // language-version ≥ 1.1.0
 }
 
 // A record with the various kinds of containers Theta supports.

--- a/test/python/theta_python_tests/test_python.py
+++ b/test/python/theta_python_tests/test_python.py
@@ -2,7 +2,7 @@ import datetime
 import io
 from hypothesis import given
 from hypothesis.strategies import binary, booleans, builds, dates, datetimes, \
-     dictionaries, floats, integers, lists, none, one_of, text, uuids
+     dictionaries, floats, integers, lists, none, one_of, text, uuids, times
 import unittest
 
 from theta import avro
@@ -42,7 +42,9 @@ primitives = builds(Primitives,
                     text(),
                     dates(),
                     datetimes(),
-                    uuids())
+                    uuids(),
+                    times(),
+                    datetimes())
 
 containers = builds(Containers,
                     lists(booleans()),

--- a/test/rust/modules/primitives.theta
+++ b/test/rust/modules/primitives.theta
@@ -15,7 +15,8 @@ type Primitives = {
   date     : Date,
   datetime : Datetime,
   uuid : UUID, // language-version ≥ 1.1.0
-  time : Time // language-version ≥ 1.1.0
+  time : Time, // language-version ≥ 1.1.0
+  local_datetime : LocalDatetime // language-version ≥ 1.1.0
 }
 
 // A record with the various kinds of containers Theta supports.

--- a/test/rust/src/lib.rs
+++ b/test/rust/src/lib.rs
@@ -41,6 +41,7 @@ mod tests {
             datetime: DateTime::from_utc(NaiveDate::from_ymd(10, 11, 12).and_hms(5, 0, 0), Utc),
             uuid: Uuid::from_str("f81d4fae-7dec-11d0-a765-00a0c91e6bf6").unwrap(),
             time: NaiveTime::from_hms(12, 23, 10),
+            local_datetime: NaiveDate::from_ymd(10, 11, 12).and_hms(5, 0, 0),
         };
         assert!(check_encoding(example));
     }
@@ -129,6 +130,7 @@ mod tests {
             datetime: DateTime::from_utc(NaiveDate::from_ymd(10, 11, 12).and_hms(5, 0, 0), Utc),
             uuid: Uuid::from_str("f81d4fae-7dec-11d0-a765-00a0c91e6bf6").unwrap(),
             time: NaiveTime::from_hms(12, 23, 10),
+            local_datetime: NaiveDate::from_ymd(10, 11, 12).and_hms(5, 0, 0),
         };
         let shadowing_record = shadowing::shadowing::Primitives {
             underlying: shadowed_record.clone(),

--- a/theta/src/Theta/Primitive.hs
+++ b/theta/src/Theta/Primitive.hs
@@ -51,10 +51,10 @@ data Primitive = Bool
                | String
                -- ^ Unicode-aware strings
                | Date
-               -- ^ An absolute date (eg @2020-01-10@) with no time
-               -- attached
+               -- ^ An absolute date (eg @2020-01-10@) with no
+               -- timezone/locale specified.
                | Datetime
-               -- ^ An absolute timestamp in UTC (no locale/timezone)
+               -- ^ An absolute timestamp in UTC.
                | UUID
                -- ^ A universally unique identifier (UUID), conforming
                -- to [RFC 4122](https://www.ietf.org/rfc/rfc4122.txt)
@@ -62,16 +62,21 @@ data Primitive = Bool
                -- Example: @f81d4fae-7dec-11d0-a765-00a0c91e6bf6@
                | Time
                -- ^ The time of day, starting at midnight.
+               | LocalDatetime
+               -- ^ An absolute timestamp in whatever timezone is
+               -- considered local. (No timezone/locale is specified.)
  deriving stock (Eq, Show, Ord, Enum, Bounded, Lift)
 
 instance Pretty Primitive where pretty = primitiveKeyword
 
 -- | Returns a canonical name for each primitive type.
 --
--- Primitive types have definitions in the @theta.primitive@ module,
--- so that's the canonical namespace. @Int@ become
--- @theta.primitive.Int@, @String@ becomes
+-- Primitive types have @theta.primitive@ as their canonical
+-- namespace. @Int@ become @theta.primitive.Int@, @String@ becomes
 -- @theta.primitive.String@... etc.
+--
+-- Currently these names are not defined in Theta itself, but that
+-- will probably change in the future.
 primitiveName :: Primitive -> Name
 primitiveName = Name "theta.primitive" . primitiveKeyword
 
@@ -89,17 +94,18 @@ hashPrimitive = hashName . primitiveName
 -- | The earliest @language-version@ that supports the given primitive
 -- type.
 definedIn :: Primitive -> Version
-definedIn Bool     = "1.0.0"
-definedIn Bytes    = "1.0.0"
-definedIn Int      = "1.0.0"
-definedIn Long     = "1.0.0"
-definedIn Float    = "1.0.0"
-definedIn Double   = "1.0.0"
-definedIn String   = "1.0.0"
-definedIn Date     = "1.0.0"
-definedIn Datetime = "1.0.0"
-definedIn UUID     = "1.1.0"
-definedIn Time     = "1.1.0"
+definedIn Bool          = "1.0.0"
+definedIn Bytes         = "1.0.0"
+definedIn Int           = "1.0.0"
+definedIn Long          = "1.0.0"
+definedIn Float         = "1.0.0"
+definedIn Double        = "1.0.0"
+definedIn String        = "1.0.0"
+definedIn Date          = "1.0.0"
+definedIn Datetime      = "1.0.0"
+definedIn UUID          = "1.1.0"
+definedIn Time          = "1.1.0"
+definedIn LocalDatetime = "1.1.0"
 
 -- | Every single primitive type supported by Theta.
 primitives :: [Primitive]

--- a/theta/src/Theta/Target/Avro/Types.hs
+++ b/theta/src/Theta/Target/Avro/Types.hs
@@ -335,9 +335,9 @@ primitiveType contextAvroVersion = \case
     | contextAvroVersion < "1.1.0" -> Avro.Long Nothing
     | otherwise                    -> Avro.Long (Just Avro.TimestampMicros)
 
-  Theta.UUID -> Avro.String (Just Avro.UUID)
-
-  Theta.Time -> Avro.Long (Just Avro.TimeMicros)
+  Theta.UUID          -> Avro.String (Just Avro.UUID)
+  Theta.Time          -> Avro.Long (Just Avro.TimeMicros)
+  Theta.LocalDatetime -> Avro.Long Nothing
 
 -- | Transforms any Theta expression into a fragment of an Avro
 -- schema. This schema might not stand alone—for example, it could

--- a/theta/src/Theta/Target/Avro/Values.hs
+++ b/theta/src/Theta/Target/Avro/Values.hs
@@ -48,7 +48,8 @@ import qualified Data.List.NonEmpty          as NonEmpty
 import qualified Data.Set                    as Set
 import           Data.Text                   (Text)
 import qualified Data.Text                   as Text
-import           Data.Time                   (TimeOfDay, picosecondsToDiffTime)
+import           Data.Time                   (LocalTime, TimeOfDay,
+                                              picosecondsToDiffTime)
 import qualified Data.Time                   as Time
 import qualified Data.UUID                   as UUID
 import           Data.Vector                 (Vector)
@@ -89,17 +90,18 @@ toAvro value@Value { type_ } = do
 
           -- primitive types
           (readSchema, Primitive v) -> case (readSchema, v) of
-            (ReadSchema.Boolean, Boolean b)   -> Avro.Boolean b
-            (ReadSchema.Bytes _, Bytes bs)    -> Avro.Bytes schema (LBS.toStrict bs)
-            (ReadSchema.Int _, Int i)         -> Avro.Int schema i
-            (ReadSchema.Long _ _, Long l)     -> Avro.Long schema l
-            (ReadSchema.Float _, Float f)     -> Avro.Float schema f
-            (ReadSchema.Double _, Double d)   -> Avro.Double schema d
-            (ReadSchema.String _, String t)   -> Avro.String schema t
-            (ReadSchema.Int _, Date d)        -> Avro.Int schema $ fromDay d
-            (ReadSchema.Long _ _, Datetime t) -> Avro.Long schema $ fromUTCTime t
-            (ReadSchema.String _, UUID u)     -> Avro.String schema $ UUID.toText u
-            (ReadSchema.Long _ _, Time t)     -> Avro.Long schema $ fromTimeOfDay t
+            (ReadSchema.Boolean, Boolean b)        -> Avro.Boolean b
+            (ReadSchema.Bytes _, Bytes bs)         -> Avro.Bytes schema (LBS.toStrict bs)
+            (ReadSchema.Int _, Int i)              -> Avro.Int schema i
+            (ReadSchema.Long _ _, Long l)          -> Avro.Long schema l
+            (ReadSchema.Float _, Float f)          -> Avro.Float schema f
+            (ReadSchema.Double _, Double d)        -> Avro.Double schema d
+            (ReadSchema.String _, String t)        -> Avro.String schema t
+            (ReadSchema.Int _, Date d)             -> Avro.Int schema $ fromDay d
+            (ReadSchema.Long _ _, Datetime t)      -> Avro.Long schema $ fromUTCTime t
+            (ReadSchema.String _, UUID u)          -> Avro.String schema $ UUID.toText u
+            (ReadSchema.Long _ _, Time t)          -> Avro.Long schema $ fromTimeOfDay t
+            (ReadSchema.Long _ _, LocalDatetime t) -> Avro.Long schema $ fromLocalTime t
 
             (_, _) -> error $ "Mismatch between the type_ and value of a Value. \
                               \This is a bug in the Theta implementation.\n"
@@ -225,20 +227,23 @@ fromAvro type_@Theta.Type { baseType, module_ } avro = do
 
           -- primitive types
           (Theta.Primitive' t, avro) -> case (t, avro) of
-            (Theta.Bool, Avro.Boolean b)    -> wrapPrimitive $ Boolean b
-            (Theta.Bytes, Avro.Bytes _ bs)  -> wrapPrimitive $ Bytes $ LBS.fromStrict bs
-            (Theta.Int, Avro.Int _ i)       -> wrapPrimitive $ Int i
-            (Theta.Long, Avro.Long _ l)     -> wrapPrimitive $ Long l
-            (Theta.Float, Avro.Float _ f)   -> wrapPrimitive $ Float f
-            (Theta.Double, Avro.Double _ d) -> wrapPrimitive $ Double d
-            (Theta.String, Avro.String _ t) -> wrapPrimitive $ String t
-            (Theta.Date, Avro.Int _ i)      -> wrapPrimitive $ Date $ toDay i
-            (Theta.Datetime, Avro.Long _ l) -> wrapPrimitive $ Datetime $ toUTCTime l
-            (Theta.UUID, Avro.String _ s)   -> case UUID.fromText s of
-              Just uuid -> wrapPrimitive $ UUID uuid
-              Nothing   -> throw $ InvalidUUID s
-            (Theta.Time, Avro.Long _ l)     -> wrapPrimitive $ Time $ toTimeOfDay l
-            (_, got)                        -> throw $ TypeMismatch type_ got
+            (Theta.Bool, Avro.Boolean b)         -> wrapPrimitive $ Boolean b
+            (Theta.Bytes, Avro.Bytes _ bs)       ->
+              wrapPrimitive $ Bytes $ LBS.fromStrict bs
+            (Theta.Int, Avro.Int _ i)            -> wrapPrimitive $ Int i
+            (Theta.Long, Avro.Long _ l)          -> wrapPrimitive $ Long l
+            (Theta.Float, Avro.Float _ f)        -> wrapPrimitive $ Float f
+            (Theta.Double, Avro.Double _ d)      -> wrapPrimitive $ Double d
+            (Theta.String, Avro.String _ t)      -> wrapPrimitive $ String t
+            (Theta.Date, Avro.Int _ i)           -> wrapPrimitive $ Date $ toDay i
+            (Theta.Datetime, Avro.Long _ l)      -> wrapPrimitive $ Datetime $ toUTCTime l
+            (Theta.UUID, Avro.String _ s)        -> case UUID.fromText s of
+              Just uuid                          -> wrapPrimitive $ UUID uuid
+              Nothing                            -> throw $ InvalidUUID s
+            (Theta.Time, Avro.Long _ l)          -> wrapPrimitive $ Time $ toTimeOfDay l
+            (Theta.LocalDatetime, Avro.Long _ l) ->
+              wrapPrimitive $ LocalDatetime $ toLocalTime l
+            (_, got)                             -> throw $ TypeMismatch type_ got
 
           -- containers
           (Theta.Array' t, Avro.Array xs)   ->
@@ -428,7 +433,8 @@ fromUTCTime (Time.UTCTime day inDay) = fromInteger $ days * dayLength + micros
         micros = Time.diffTimeToPicoseconds inDay `div` 1e6
 {-# INLINE fromUTCTime #-}
 
--- | Convert an Avro-style microsecond-precision time to a 'DayTime'.
+-- | Convert an Avro-style microsecond-precision time to a
+-- 'TimeOfDay'.
 --
 -- The Avro format for time is a long storing the number of
 -- microseconds from midnight.
@@ -436,12 +442,24 @@ toTimeOfDay :: Int64 -> TimeOfDay
 toTimeOfDay (fromIntegral -> microseconds) =
   Time.timeToTimeOfDay $ picosecondsToDiffTime $ microseconds * 1e6
 
--- | Convert a 'DayTime' to a 'Long' containing the number of
+-- | Convert a 'TimeOfDay' to a long containing the number of
 -- microseconds since midnight.
 fromTimeOfDay :: TimeOfDay -> Int64
 fromTimeOfDay = fromDiffTime . Time.timeOfDayToTime
   where fromDiffTime time = fromInteger $ Time.diffTimeToPicoseconds time `div` 1e6
 
+-- | Convert an Avro-style microsecond-precision timestamp to a
+-- 'LocalTime'.
+--
+-- The Avro format for time is a long storing the number of
+-- microseconds from midnight.
+toLocalTime :: Int64 -> LocalTime
+toLocalTime = Time.utcToLocalTime Time.utc . toUTCTime
+
+-- | Convert a 'LocalTime' to a long containing the number of
+-- microseconds since 1970-01-01.
+fromLocalTime :: LocalTime -> Int64
+fromLocalTime = fromUTCTime . Time.localTimeToUTC Time.utc
 
 -- | Convert an Avro name to the corresponding Theta name.
 --

--- a/theta/src/Theta/Target/Haskell.hs
+++ b/theta/src/Theta/Target/Haskell.hs
@@ -80,7 +80,8 @@ import qualified Data.Set                        as Set
 import           Data.Tagged                     (Tagged (..))
 import           Data.Text                       (Text)
 import qualified Data.Text                       as Text
-import           Data.Time                       (Day, TimeOfDay, UTCTime)
+import           Data.Time                       (Day, LocalTime, TimeOfDay,
+                                                  UTCTime)
 import           Data.UUID                       (UUID)
 import           Data.Vector                     ((!))
 import qualified Data.Vector                     as Vector
@@ -253,17 +254,18 @@ generateModule (Theta.Module name (Map.toList -> bindings) imports metadata) =
 generateThetaExp :: Theta.Type -> TH.Q TH.Exp
 generateThetaExp type_ = case Theta.baseType type_ of
   Theta.Primitive' p -> case p of
-    Primitive.Bool     -> [e| Theta.bool' |]
-    Primitive.Bytes    -> [e| Theta.bytes' |]
-    Primitive.Int      -> [e| Theta.int' |]
-    Primitive.Long     -> [e| Theta.long' |]
-    Primitive.Float    -> [e| Theta.float' |]
-    Primitive.Double   -> [e| Theta.double' |]
-    Primitive.String   -> [e| Theta.string' |]
-    Primitive.Date     -> [e| Theta.date' |]
-    Primitive.Datetime -> [e| Theta.datetime' |]
-    Primitive.UUID     -> [e| Theta.uuid' |]
-    Primitive.Time     -> [e| Theta.time' |]
+    Primitive.Bool          -> [e| Theta.bool' |]
+    Primitive.Bytes         -> [e| Theta.bytes' |]
+    Primitive.Int           -> [e| Theta.int' |]
+    Primitive.Long          -> [e| Theta.long' |]
+    Primitive.Float         -> [e| Theta.float' |]
+    Primitive.Double        -> [e| Theta.double' |]
+    Primitive.String        -> [e| Theta.string' |]
+    Primitive.Date          -> [e| Theta.date' |]
+    Primitive.Datetime      -> [e| Theta.datetime' |]
+    Primitive.UUID          -> [e| Theta.uuid' |]
+    Primitive.Time          -> [e| Theta.time' |]
+    Primitive.LocalDatetime -> [e| Theta.localDatetime' |]
 
   Theta.Array' type_        -> [e| Theta.array' $(generateThetaExp type_) |]
   Theta.Map' type_          -> [e| Theta.map' $(generateThetaExp type_) |]
@@ -1178,17 +1180,18 @@ variantFromTheta name (toList -> cases) =
 generateType :: Theta.Type -> TH.Q TH.Type
 generateType type_ = case Theta.baseType type_ of
   Theta.Primitive' p    -> case p of
-    Primitive.Bool     -> [t| Bool |]
-    Primitive.Bytes    -> [t| ByteString |]
-    Primitive.Int      -> [t| Int32 |]
-    Primitive.Long     -> [t| Int64 |]
-    Primitive.Float    -> [t| Float |]
-    Primitive.Double   -> [t| Double |]
-    Primitive.String   -> [t| Text |]
-    Primitive.Date     -> [t| Day |]
-    Primitive.Datetime -> [t| UTCTime |]
-    Primitive.UUID     -> [t| UUID |]
-    Primitive.Time     -> [t| TimeOfDay |]
+    Primitive.Bool          -> [t| Bool |]
+    Primitive.Bytes         -> [t| ByteString |]
+    Primitive.Int           -> [t| Int32 |]
+    Primitive.Long          -> [t| Int64 |]
+    Primitive.Float         -> [t| Float |]
+    Primitive.Double        -> [t| Double |]
+    Primitive.String        -> [t| Text |]
+    Primitive.Date          -> [t| Day |]
+    Primitive.Datetime      -> [t| UTCTime |]
+    Primitive.UUID          -> [t| UUID |]
+    Primitive.Time          -> [t| TimeOfDay |]
+    Primitive.LocalDatetime -> [t| LocalTime |]
 
   Theta.Array' items    -> [t| [$(generateType items)] |]
   Theta.Map' values     -> [t| HashMap Text $(generateType values) |]

--- a/theta/src/Theta/Target/Haskell/Conversion.hs
+++ b/theta/src/Theta/Target/Haskell/Conversion.hs
@@ -42,7 +42,8 @@ import qualified Data.HashMap.Strict           as HashMap
 import           Data.Int                      (Int32, Int64)
 import           Data.Text                     (Text)
 import qualified Data.Text                     as Text
-import           Data.Time                     (Day, TimeOfDay, UTCTime)
+import           Data.Time                     (Day, LocalTime, TimeOfDay,
+                                                UTCTime)
 import           Data.UUID                     (UUID)
 import qualified Data.UUID                     as UUID
 import qualified Data.Vector                   as Vector
@@ -287,6 +288,18 @@ instance FromTheta TimeOfDay where
     _                                 -> mismatch Theta.time' type_
 
   avroDecoding = Values.toTimeOfDay <$> DecodeRaw.decodeRaw @Int64
+
+instance ToTheta LocalTime where
+  toTheta = Theta.localDatetime
+
+  avroEncoding = avroEncoding . Values.fromLocalTime
+
+instance FromTheta LocalTime where
+  fromTheta' Theta.Value { Theta.type_, Theta.value } = case value of
+    Theta.Primitive (Theta.LocalDatetime time) -> pure time
+    _                                          -> mismatch Theta.localDatetime' type_
+
+  avroDecoding = Values.toLocalTime <$> DecodeRaw.decodeRaw @Int64
 
 instance ToTheta a => ToTheta [a] where
   toTheta values = Theta.Value

--- a/theta/src/Theta/Target/Haskell/HasTheta.hs
+++ b/theta/src/Theta/Target/Haskell/HasTheta.hs
@@ -14,7 +14,7 @@ import           Data.ByteString.Lazy (ByteString)
 import           Data.HashMap.Strict  (HashMap)
 import           Data.Int             (Int32, Int64)
 import           Data.Text            (Text)
-import           Data.Time            (Day, TimeOfDay, UTCTime)
+import           Data.Time            (Day, LocalTime, TimeOfDay, UTCTime)
 import           Data.UUID            (UUID)
 
 import qualified Theta.Types          as Theta
@@ -63,6 +63,9 @@ instance HasTheta UUID where
 
 instance HasTheta TimeOfDay where
   theta = Theta.time'
+
+instance HasTheta LocalTime where
+  theta = Theta.localDatetime'
 
 instance HasTheta a => HasTheta [a] where
   theta = Theta.array' $ theta @a

--- a/theta/src/Theta/Target/Kotlin.hs
+++ b/theta/src/Theta/Target/Kotlin.hs
@@ -56,6 +56,7 @@ toModule prefix Theta.Module {..} =
     import java.time.LocalDate
     import java.time.LocalDateTime
     import java.time.LocalTime
+    import java.time.OffsetDateTime
 
     import java.util.UUID
 
@@ -177,17 +178,18 @@ toReference Theta.Type { Theta.baseType } = case baseType of
 
   -- primitive types
   Theta.Primitive' t -> case t of
-    Theta.Bool     -> "Boolean"
-    Theta.Bytes    -> "ByteArray"
-    Theta.Int      -> "Int"
-    Theta.Long     -> "Long"
-    Theta.Float    -> "Float"
-    Theta.Double   -> "Double"
-    Theta.String   -> "String"
-    Theta.Date     -> "LocalDate"
-    Theta.Datetime -> "LocalDateTime"
-    Theta.UUID     -> "UUID"
-    Theta.Time     -> "LocalTime"
+    Theta.Bool          -> "Boolean"
+    Theta.Bytes         -> "ByteArray"
+    Theta.Int           -> "Int"
+    Theta.Long          -> "Long"
+    Theta.Float         -> "Float"
+    Theta.Double        -> "Double"
+    Theta.String        -> "String"
+    Theta.Date          -> "LocalDate"
+    Theta.Datetime      -> "OffsetDateTime"
+    Theta.UUID          -> "UUID"
+    Theta.Time          -> "LocalTime"
+    Theta.LocalDatetime -> "LocalDateTime"
 
   -- containers
   Theta.Array' a        -> let items = toReference a in [kotlin|Array<$items>|]

--- a/theta/src/Theta/Target/Python.hs
+++ b/theta/src/Theta/Target/Python.hs
@@ -91,17 +91,18 @@ toModule Theta.Module {..} prefix = do
 
 -- | The Python type that corresponds to each primitive Theta type.
 primitive :: Theta.Primitive -> Python
-primitive Theta.Bool     = "bool"
-primitive Theta.Bytes    = "bytes"
-primitive Theta.Int      = "int"
-primitive Theta.Long     = "int"
-primitive Theta.Float    = "float"
-primitive Theta.Double   = "float"
-primitive Theta.String   = "str"
-primitive Theta.Date     = "date"
-primitive Theta.Datetime = "datetime"
-primitive Theta.UUID     = "UUID"
-primitive Theta.Time     = "time"
+primitive Theta.Bool          = "bool"
+primitive Theta.Bytes         = "bytes"
+primitive Theta.Int           = "int"
+primitive Theta.Long          = "int"
+primitive Theta.Float         = "float"
+primitive Theta.Double        = "float"
+primitive Theta.String        = "str"
+primitive Theta.Date          = "date"
+primitive Theta.Datetime      = "datetime"
+primitive Theta.UUID          = "UUID"
+primitive Theta.Time          = "time"
+primitive Theta.LocalDatetime = "datetime"
 
 -- | Return a Python snippet that /refers/ to the given Theta"a"
 --
@@ -468,17 +469,18 @@ encodingFunction Theta.Type { Theta.baseType, Theta.module_ } = case baseType of
 
   -- Primitive Types
   Theta.Primitive' t -> pure $ case t of
-    Theta.Bool     -> "encoder.bool"
-    Theta.Bytes    -> "encoder.bytes"
-    Theta.Int      -> "encoder.integral"
-    Theta.Long     -> "encoder.integral"
-    Theta.Float    -> "encoder.float"
-    Theta.Double   -> "encoder.double"
-    Theta.String   -> "encoder.string"
-    Theta.Date     -> "encoder.date"
-    Theta.Datetime -> "encoder.datetime"
-    Theta.UUID     -> "encoder.uuid"
-    Theta.Time     -> "encoder.time"
+    Theta.Bool          -> "encoder.bool"
+    Theta.Bytes         -> "encoder.bytes"
+    Theta.Int           -> "encoder.integral"
+    Theta.Long          -> "encoder.integral"
+    Theta.Float         -> "encoder.float"
+    Theta.Double        -> "encoder.double"
+    Theta.String        -> "encoder.string"
+    Theta.Date          -> "encoder.date"
+    Theta.Datetime      -> "encoder.datetime"
+    Theta.UUID          -> "encoder.uuid"
+    Theta.Time          -> "encoder.time"
+    Theta.LocalDatetime -> "encoder.datetime"
 
   -- Containers
   Theta.Array' type_    -> do
@@ -533,17 +535,18 @@ decodingFunction prefix currentModule Theta.Type { Theta.baseType, Theta.module_
   case baseType of
     -- Primitive Types
     Theta.Primitive' t -> pure $ case t of
-      Theta.Bool     -> "decoder.bool()"
-      Theta.Bytes    -> "decoder.bytes()"
-      Theta.Int      -> "decoder.integral()"
-      Theta.Long     -> "decoder.integral()"
-      Theta.Float    -> "decoder.float()"
-      Theta.Double   -> "decoder.double()"
-      Theta.String   -> "decoder.string()"
-      Theta.Date     -> "decoder.date()"
-      Theta.Datetime -> "decoder.datetime()"
-      Theta.UUID     -> "decoder.uuid()"
-      Theta.Time     -> "decoder.time()"
+      Theta.Bool          -> "decoder.bool()"
+      Theta.Bytes         -> "decoder.bytes()"
+      Theta.Int           -> "decoder.integral()"
+      Theta.Long          -> "decoder.integral()"
+      Theta.Float         -> "decoder.float()"
+      Theta.Double        -> "decoder.double()"
+      Theta.String        -> "decoder.string()"
+      Theta.Date          -> "decoder.date()"
+      Theta.Datetime      -> "decoder.datetime()"
+      Theta.UUID          -> "decoder.uuid()"
+      Theta.Time          -> "decoder.time()"
+      Theta.LocalDatetime -> "decoder.datetime()"
 
     -- Containers
     Theta.Array' type_ -> do

--- a/theta/src/Theta/Target/Rust.hs
+++ b/theta/src/Theta/Target/Rust.hs
@@ -95,7 +95,7 @@ toModule Theta.Module { Theta.types } = definitionLines $ imports : typeDefiniti
   where typeDefinitions = toDefinition <$> Map.elems types
 
         imports = [rust|
-          use chrono::{Date, DateTime, NaiveTime, Utc};
+          use chrono::{Date, DateTime, NaiveDateTime, NaiveTime, Utc};
           use std::collections::HashMap;
           use theta::avro::{FromAvro, ToAvro};
           use nom::{IResult, Err, error::{context, ErrorKind}};
@@ -167,17 +167,18 @@ typeIdentifier :: Theta.Type -> [Rust]
 typeIdentifier Theta.Type { Theta.baseType } = case baseType of
   -- primitive types
   Theta.Primitive' p -> case p of
-    Theta.Bool     -> ["bool"]
-    Theta.Bytes    -> ["Vec"]
-    Theta.Int      -> ["i32"]
-    Theta.Long     -> ["i64"]
-    Theta.Float    -> ["f32"]
-    Theta.Double   -> ["f64"]
-    Theta.String   -> ["String"]
-    Theta.Date     -> ["Date"]
-    Theta.Datetime -> ["DateTime"]
-    Theta.UUID     -> ["Uuid"]
-    Theta.Time     -> ["NaiveTime"]
+    Theta.Bool          -> ["bool"]
+    Theta.Bytes         -> ["Vec"]
+    Theta.Int           -> ["i32"]
+    Theta.Long          -> ["i64"]
+    Theta.Float         -> ["f32"]
+    Theta.Double        -> ["f64"]
+    Theta.String        -> ["String"]
+    Theta.Date          -> ["Date"]
+    Theta.Datetime      -> ["DateTime"]
+    Theta.UUID          -> ["Uuid"]
+    Theta.Time          -> ["NaiveTime"]
+    Theta.LocalDatetime -> ["NaiveDateTime"]
 
   -- containers
   Theta.Array' _        -> ["Vec"]

--- a/theta/src/Theta/Types.hs
+++ b/theta/src/Theta/Types.hs
@@ -508,6 +508,9 @@ uuid' = wrapPrimitive UUID
 time' :: Type
 time' = wrapPrimitive Time
 
+localDatetime' :: Type
+localDatetime' = wrapPrimitive LocalDatetime
+
 array' :: Type -> Type
 array' t = Type
   { baseType = Array' t

--- a/theta/test/Test/Assertions.hs
+++ b/theta/test/Test/Assertions.hs
@@ -28,7 +28,7 @@ import           Prettyprinter.Render.Terminal (AnsiStyle,
 
 import qualified Test.Tasty.HUnit              as HUnit
 
-import           Data.Time                     (TimeOfDay)
+import           Data.Time                     (TimeOfDay, LocalTime)
 import           Theta.Target.LanguageQuoter   (Interpolable, toText)
 
 -- * Human-Readable Diffs
@@ -126,3 +126,6 @@ a ?= b = when (normalize a /= normalize b) $ do
 
 instance ToExpr TimeOfDay where
   toExpr t = App "TimeOfDay" [toExpr $ show t]
+
+instance ToExpr LocalTime where
+  toExpr t = App "LocalTime" [toExpr $ show t]

--- a/theta/test/Test/Theta/Target/Haskell.hs
+++ b/theta/test/Test/Theta/Target/Haskell.hs
@@ -67,7 +67,8 @@ test_primitives = testGroup "primitives"
   , testCase "fromAvro ∘ toAvro = id" $ do
       Avro.decodeValue (Avro.encodeValue primitives) @?= Right primitives
   ]
-  where primitives = Primitives True "blarg" 37 42 1.2 7.4 "foo" today now uuid time
+  where primitives =
+          Primitives True "blarg" 37 42 1.2 7.4 "foo" today now uuid time localTime
         expected = Theta.Record
           [ Theta.boolean True
           , Theta.bytes "blarg"
@@ -80,11 +81,13 @@ test_primitives = testGroup "primitives"
           , Theta.datetime now
           , Theta.uuid uuid
           , Theta.time time
+          , Theta.localDatetime localTime
           ]
 
         today = read "2019-02-11"
         now   = read "2019-02-11 14:23:12 UTC"
         time  = read "14:23:12"
+        localTime = read "2019-02-11 14:23:12"
         uuid  = fromMaybe (error "Invalid UUID literal.") $
           UUID.fromText "f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
 

--- a/theta/test/Test/Theta/Target/Kotlin.hs
+++ b/theta/test/Test/Theta/Target/Kotlin.hs
@@ -156,6 +156,7 @@ test_toModule = testGroup "toModule"
         import java.time.LocalDate
         import java.time.LocalDateTime
         import java.time.LocalTime
+        import java.time.OffsetDateTime
 
         import java.util.UUID
 
@@ -177,6 +178,7 @@ test_toModule = testGroup "toModule"
         import java.time.LocalDate
         import java.time.LocalDateTime
         import java.time.LocalTime
+        import java.time.OffsetDateTime
 
         import java.util.UUID
 
@@ -196,6 +198,7 @@ test_toModule = testGroup "toModule"
         import java.time.LocalDate
         import java.time.LocalDateTime
         import java.time.LocalTime
+        import java.time.OffsetDateTime
 
         import java.util.UUID
 

--- a/theta/test/Test/Theta/Types.hs
+++ b/theta/test/Test/Theta/Types.hs
@@ -68,21 +68,9 @@ test_eq = testGroup "Eq instance"
         in
         assertBool message (s /= t)
   ]
-  where basicTypes :: [Theta.Type]
-        basicTypes =
-          [ Theta.bool'
-          , Theta.bytes'
-          , Theta.int'
-          , Theta.long'
-          , Theta.float'
-          , Theta.double'
-          , Theta.string'
-          , Theta.date'
-          , Theta.datetime'
-          , Theta.uuid'
-          , Theta.time'
-
-          , Theta.array' Theta.int'
+  where basicTypes = Theta.primitiveTypes <> structuredTypes
+        structuredTypes = 
+          [ Theta.array' Theta.int'
           , Theta.map' Theta.int'
           , Theta.optional' Theta.int'
 
@@ -103,18 +91,7 @@ test_eq = testGroup "Eq instance"
         -- basicTypes list too
         checkType type_ = case Theta.baseType type_ of
           -- primitive types
-          Theta.Primitive' p -> case p of
-            Theta.Bool     -> type_ @?= type_
-            Theta.Bytes    -> type_ @?= type_
-            Theta.Int      -> type_ @?= type_
-            Theta.Long     -> type_ @?= type_
-            Theta.Float    -> type_ @?= type_
-            Theta.Double   -> type_ @?= type_
-            Theta.String   -> type_ @?= type_
-            Theta.Date     -> type_ @?= type_
-            Theta.Datetime -> type_ @?= type_
-            Theta.UUID     -> type_ @?= type_
-            Theta.Time     -> type_ @?= type_
+          Theta.Primitive'{} -> type_ @?= type_
 
           -- containers
           Theta.Array'{}     -> type_ @?= type_
@@ -236,17 +213,18 @@ test_hashing = testGroup "hashing"
         -- defining this as a function gives us a warning if we add
         -- new primitive types but don't update this test case
         let expectedPrimitive t = case t of
-              Theta.Bool     -> "368b9de4188c87e7afa1d7867dcf4413"
-              Theta.Bytes    -> "0fa7cf75524be7f38afd4c156a8806ca"
-              Theta.Int      -> "43d51ed7739b75a3636f33b75c599255"
-              Theta.Long     -> "bd1906da131060d558fff8de56142006"
-              Theta.Float    -> "f3e66d7cfcf8cec4e28182bfaee67c00"
-              Theta.Double   -> "d42662766a376211229617337bd427a9"
-              Theta.String   -> "4b041ed503e3481e6341363865732ab2"
-              Theta.Date     -> "f9796917d9806a980c089cae18f6d57e"
-              Theta.Datetime -> "e5158c40b7bc0dd7b50340fdb08e3c2b"
-              Theta.UUID     -> "d2e4edd151c5d24637c63111311b13d1"
-              Theta.Time     -> "d25ae4f8007c356e61dcd841309ca82e"
+              Theta.Bool          -> "368b9de4188c87e7afa1d7867dcf4413"
+              Theta.Bytes         -> "0fa7cf75524be7f38afd4c156a8806ca"
+              Theta.Int           -> "43d51ed7739b75a3636f33b75c599255"
+              Theta.Long          -> "bd1906da131060d558fff8de56142006"
+              Theta.Float         -> "f3e66d7cfcf8cec4e28182bfaee67c00"
+              Theta.Double        -> "d42662766a376211229617337bd427a9"
+              Theta.String        -> "4b041ed503e3481e6341363865732ab2"
+              Theta.Date          -> "f9796917d9806a980c089cae18f6d57e"
+              Theta.Datetime      -> "e5158c40b7bc0dd7b50340fdb08e3c2b"
+              Theta.UUID          -> "d2e4edd151c5d24637c63111311b13d1"
+              Theta.Time          -> "d25ae4f8007c356e61dcd841309ca82e"
+              Theta.LocalDatetime -> "ff21534ef53c910e81fddf379d04fe26"
             test name t =
               testCase name (Theta.wrapPrimitive t ?= expectedPrimitive t)
         in [ test (show t) t | t <- primitives ]

--- a/theta/test/Test/Theta/Value.hs
+++ b/theta/test/Test/Theta/Value.hs
@@ -32,7 +32,7 @@ tests :: TestTree
 tests = testGroup "Value"
   [ testProperty "primitive types" $ do
       values <- mapM genValue primitiveTypes
-      pure $ and [ type_ v == prim | v <- values | prim <- primitiveTypes ]
+      pure $ all checkValue values
 
   , testProperty "primitives.Primitives" $ do
       value <- genValue (theta @Primitives)

--- a/theta/test/data/modules/primitives.theta
+++ b/theta/test/data/modules/primitives.theta
@@ -15,7 +15,8 @@ type Primitives = {
   date     : Date,
   datetime : Datetime,
   uuid : UUID,
-  time : Time
+  time : Time,
+  local_datetime : LocalDatetime
 }
 
 type Containers = {

--- a/theta/test/data/rust/enums.rs
+++ b/theta/test/data/rust/enums.rs
@@ -1,4 +1,4 @@
-use chrono::{Date, DateTime, NaiveTime, Utc};
+use chrono::{Date, DateTime, NaiveDateTime, NaiveTime, Utc};
 use std::collections::HashMap;
 use theta::avro::{FromAvro, ToAvro};
 use nom::{IResult, Err, error::{context, ErrorKind}};

--- a/theta/test/data/rust/newtype.rs
+++ b/theta/test/data/rust/newtype.rs
@@ -1,4 +1,4 @@
-use chrono::{Date, DateTime, NaiveTime, Utc};
+use chrono::{Date, DateTime, NaiveDateTime, NaiveTime, Utc};
 use std::collections::HashMap;
 use theta::avro::{FromAvro, ToAvro};
 use nom::{IResult, Err, error::{context, ErrorKind}};

--- a/theta/test/data/rust/recursive.rs
+++ b/theta/test/data/rust/recursive.rs
@@ -1,4 +1,4 @@
-use chrono::{Date, DateTime, NaiveTime, Utc};
+use chrono::{Date, DateTime, NaiveDateTime, NaiveTime, Utc};
 use std::collections::HashMap;
 use theta::avro::{FromAvro, ToAvro};
 use nom::{IResult, Err, error::{context, ErrorKind}};

--- a/theta/test/data/rust/single_file.rs
+++ b/theta/test/data/rust/single_file.rs
@@ -5,7 +5,7 @@ pub mod newtype {
     use super::newtype;
     use super::recursive;
 
-    use chrono::{Date, DateTime, NaiveTime, Utc};
+    use chrono::{Date, DateTime, NaiveDateTime, NaiveTime, Utc};
     use std::collections::HashMap;
     use theta::avro::{FromAvro, ToAvro};
     use nom::{IResult, Err, error::{context, ErrorKind}};
@@ -54,7 +54,7 @@ pub mod recursive {
     use super::newtype;
     use super::recursive;
 
-    use chrono::{Date, DateTime, NaiveTime, Utc};
+    use chrono::{Date, DateTime, NaiveDateTime, NaiveTime, Utc};
     use std::collections::HashMap;
     use theta::avro::{FromAvro, ToAvro};
     use nom::{IResult, Err, error::{context, ErrorKind}};


### PR DESCRIPTION
This type maps to a date/time combination with no timezone. It's based on the Avro `local-timestamp-micros` logical type, but doesn't compile to that (yet) because it isn't supported by the Haskell `avro` package[^pr].

`LocalDatetime` compiles to:

  * `"long"` in Avro
  * `LocalTime` in Haskell
  * `datetime` in Python
  * `NaiveDate` in Rust
  * `LocalDateTime` in Kotlin

[^pr]: I submitted [a PR to fix this][avro-pr]. If that gets merged and released soon, I'll add support for `local-timestamp-micros` before cutting the official 1.1.0 version of Theta.

[avro-pr]: https://github.com/haskell-works/avro/pull/181