### PR TITLE
Consistent leap second handling for Time type

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -27,7 +27,7 @@ jobs:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       - name: Build Theta
-        run: nix build .#theta
+        run: nix build .#theta -L
 
       - name: Cross-Language Tests
-        run: nix build .#test
+        run: nix build .#test -L

--- a/flake.nix
+++ b/flake.nix
@@ -11,10 +11,34 @@
   outputs = { self, nixpkgs, flake-utils, naersk-flake, rust-overlay }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        theta = import ./theta { inherit pkgs; };
+        source-overrides = {
+          aeson = "2.0.3.0";
+          aeson-pretty = "0.8.9";
+          attoparsec = "0.14.4";
+          avro = "0.6.0.1";
+          hashable = "1.4.0.2";
+          OneTuple = "0.3.1";
+          quickcheck-instances = "0.3.27";
+          semialign = "1.2.0.1";
+          stache = "2.3.1";
+          streamly = "0.8.1.1";
+          streamly-bytestring = "0.1.4";
+          streamly-process = "0.2.0";
+          text-short = "0.1.5";
+          time-compat = "1.9.6.1";
+          unordered-containers = "0.2.16.0";
+          versions = "5.0.2";
+        };
+
+        overrides = new: old: {
+          foldl = pkgs.haskell.lib.doJailbreak old.foldl;
+          streamly-process = pkgs.haskell.lib.dontCheck old.streamly-process;
+        };
+
+        theta = import ./theta { inherit pkgs source-overrides overrides; };
         rust = import ./rust { inherit pkgs; };
         python = import ./python { inherit pkgs; };
-        test = import ./test { inherit pkgs lib; };
+        test = import ./test { inherit pkgs lib source-overrides overrides; };
 
         theta-overlay = final: current: {
           inherit theta;

--- a/test/cross-language/default.nix
+++ b/test/cross-language/default.nix
@@ -6,6 +6,10 @@
 
 , compiler ? pkgs.haskell.packages."${compiler-version}"
 
+, source-overrides ? {}
+
+, overrides ? {}
+
 , extra-build-tools ? []               # extra tools available for nix develop
 }:
 let
@@ -43,14 +47,9 @@ let
 in
 haskell.developPackage {
   name = "theta-tests";
-  root = (pkgs.lib.cleanSourceWith
-    {
-      src = ./.;
-      filter = path: type:
-        !(pkgs.lib.elem (baseNameOf (toString path)) excluded)
-        && !pkgs.lib.hasPrefix ".ghc.environment." (baseNameOf (toString path))
-        && pkgs.lib.cleanSourceFilter path type;
-    }).outPath;
+  root = ./.;
+
+  inherit overrides source-overrides;
 
   modifier = add-build-tools;
 

--- a/test/cross-language/modules/primitives.theta
+++ b/test/cross-language/modules/primitives.theta
@@ -4,18 +4,18 @@ avro-version: 1.1.0
 
 /// A field for each primitive type:
 type Primitives = {
-  bool     : Bool,
-  bytes    : Bytes,
-  int      : Int,
-  long     : Long,
-  float    : Float,
-  double   : Double,
-  string   : String,
-  date     : Date,
-  datetime : Datetime,
-  uuid : UUID,
-  time: Time,
-  local_datetime: LocalDatetime
+  bool           : Bool,
+  bytes          : Bytes,
+  int            : Int,
+  long           : Long,
+  float          : Float,
+  double         : Double,
+  string         : String,
+  date           : Date,
+  datetime       : Datetime,
+  uuid           : UUID,
+  time           : Time,
+  local_datetime : LocalDatetime
 }
 
 /// Each kind of container:

--- a/test/cross-language/test/Main.hs
+++ b/test/cross-language/test/Main.hs
@@ -6,9 +6,13 @@ module Main where
 
 import qualified Data.Text                       as Text
 
+import           Control.Monad                   (when)
 import           Control.Monad.Except            (runExceptT)
+import           Control.Monad.IO.Class          (liftIO)
 
 import           Data.Int                        (Int32)
+
+import           Text.Printf                     (printf)
 
 import           Test.QuickCheck                 (Arbitrary (arbitrary), Gen,
                                                   forAll, getSize)
@@ -23,6 +27,7 @@ import           Theta.Pretty                    (pretty)
 import           Theta.Target.Avro.Process       (run)
 import           Theta.Target.Haskell.Conversion (genTheta', toTheta)
 import           Theta.Target.Haskell.HasTheta   (HasTheta (theta))
+import           Theta.Test.Assertions           (assertDiff, assertFirstDiff)
 import           Theta.Value                     (Value, genValue)
 
 main :: IO ()
@@ -33,12 +38,12 @@ tests = testGroup "Cross-Lanaugage Tests"
   [ testProperty "Haskell ⇔ Rust" $
       forAll everything $ \ inputs -> handle $ do
         outputs <- run "cat_everything_rust" [] inputs
-        pure $ outputs == inputs
+        assertFirstDiff outputs inputs
 
   , testProperty "Haskell ⇔ Python" $
       forAll everything $ \ inputs -> handle $ do
         outputs <- run "cat_everything_python" [] inputs
-        pure $ outputs == inputs
+        assertFirstDiff outputs inputs
   ]
   where handle action = monadicIO $ runExceptT action >>= \case
           Left err  -> fail $ Text.unpack $ pretty err

--- a/test/cross-language/test/Test/Everything.hs
+++ b/test/cross-language/test/Test/Everything.hs
@@ -1,12 +1,27 @@
+{-# LANGUAGE DeriveAnyClass        #-}
 {-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE DerivingStrategies    #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE StandaloneDeriving    #-}
 {-# LANGUAGE TemplateHaskell       #-}
 {-# LANGUAGE TypeApplications      #-}
 module Test.Everything where
+
+import           Data.TreeDiff.Class  (ToExpr)
 
 import           Theta.Target.Haskell
 
 import           Test.Primitives
 
 loadModule "modules" "everything"
+
+deriving anyclass instance ToExpr Var
+
+deriving anyclass instance ToExpr IntWrapper
+
+deriving anyclass instance ToExpr Everything
+
+deriving anyclass instance ToExpr Options
+
+deriving anyclass instance ToExpr RecursiveList

--- a/test/cross-language/test/Test/Primitives.hs
+++ b/test/cross-language/test/Test/Primitives.hs
@@ -1,11 +1,21 @@
+{-# LANGUAGE DeriveAnyClass        #-}
 {-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE DerivingStrategies    #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE StandaloneDeriving    #-}
 {-# LANGUAGE TemplateHaskell       #-}
 {-# LANGUAGE TypeApplications      #-}
 module Test.Primitives where
+
+import           Data.TreeDiff.Class   (ToExpr)
+
+import           Theta.Test.Assertions ()
 
 import           Theta.Target.Haskell
 
 loadModule "modules" "primitives"
 
+deriving anyclass instance ToExpr Primitives
+
+deriving anyclass instance ToExpr Containers

--- a/test/cross-language/theta-tests.cabal
+++ b/test/cross-language/theta-tests.cabal
@@ -15,6 +15,7 @@ common shared
 
                , mtl
                , text
+               , tree-diff >=0.2 && <0.3
 
                , theta ==1.*
                , tasty

--- a/test/default.nix
+++ b/test/default.nix
@@ -1,9 +1,9 @@
-{ pkgs, lib }:
+{ pkgs, lib, source-overrides, overrides }:
 pkgs.linkFarmFromDrvs "theta-tests" [
   (import ./avro           { inherit pkgs; })
   (import ./cli            { inherit pkgs; })
   (import ./kotlin         { inherit pkgs; })
   (import ./python         { inherit pkgs lib; })
   (import ./rust           { inherit pkgs; })
-  (import ./cross-language { inherit pkgs lib; })
+  (import ./cross-language { inherit pkgs lib source-overrides overrides; })
 ]

--- a/theta/default.nix
+++ b/theta/default.nix
@@ -4,24 +4,9 @@
 
 , compiler ? pkgs.haskell.packages."${compiler-version}"
 
-, source-overrides ? {
-  aeson = "2.0.3.0";
-  aeson-pretty = "0.8.9";
-  attoparsec = "0.14.4";
-  avro = "0.6.0.1";
-  hashable = "1.4.0.2";
-  OneTuple = "0.3.1";
-  quickcheck-instances = "0.3.27";
-  semialign = "1.2.0.1";
-  stache = "2.3.1";
-  streamly = "0.8.1.1";
-  streamly-bytestring = "0.1.4";
-  streamly-process = "0.2.0";
-  text-short = "0.1.5";
-  time-compat = "1.9.6.1";
-  unordered-containers = "0.2.16.0";
-  versions = "5.0.2";
-}
+, overrides ? (new: old: {})
+
+, source-overrides ? {}
 
 , build-tools ? [               # extra tools available for nix develop
   compiler.stylish-haskell
@@ -84,20 +69,9 @@ let
 in
 compiler.developPackage {
   name = "theta";
-  root = (pkgs.lib.cleanSourceWith
-    {
-      src = ./.;
-      filter = path: type:
-           !(pkgs.lib.elem (baseNameOf (toString path)) excluded)
-        && !pkgs.lib.hasPrefix ".ghc.environment." (baseNameOf (toString path))
-        && pkgs.lib.cleanSourceFilter path type;
-    }).outPath;
+  root = ./.;
 
-  inherit source-overrides;
-  overrides = new: old: {
-    foldl = lib.doJailbreak old.foldl;
-    streamly-process = lib.dontCheck old.streamly-process;
-  };
+  inherit overrides source-overrides;
 
   # Don't try to build static executables on Darwin systems
   modifier = let

--- a/theta/src/Theta/Primitive.hs
+++ b/theta/src/Theta/Primitive.hs
@@ -62,6 +62,10 @@ data Primitive = Bool
                -- Example: @f81d4fae-7dec-11d0-a765-00a0c91e6bf6@
                | Time
                -- ^ The time of day, starting at midnight.
+               --
+               -- Language support for leap seconds is inconsistent,
+               -- so Theta's Time type explicitly does not support
+               -- leap seconds.
                | LocalDatetime
                -- ^ An absolute timestamp in whatever timezone is
                -- considered local. (No timezone/locale is specified.)

--- a/theta/src/Theta/Test/Assertions.hs
+++ b/theta/src/Theta/Test/Assertions.hs
@@ -1,22 +1,32 @@
 {-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE OverloadedLists   #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ViewPatterns      #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 -- | Helper functions for testing: assertions/etc with human-readable
 -- diff outputs.
-module Test.Assertions where
+module Theta.Test.Assertions where
 
+import           Control.Arrow                 (Arrow (first))
 import           Control.Monad                 (when)
 
 import qualified Data.Algorithm.Diff           as Diff
 import qualified Data.Algorithm.DiffOutput     as Diff
+import           Data.Foldable                 (Foldable (toList))
+import           Data.Functor                  ((<&>))
+import qualified Data.List                     as List
+import           Data.Maybe                    (isJust)
+import           Data.Sequence                 ((|>))
 import           Data.Text                     (Text)
 import qualified Data.Text                     as Text
-import           Data.TreeDiff                 (Edit, EditExpr, Expr (App), GToExpr,
+import           Data.Time                     (LocalTime, TimeOfDay)
+import           Data.TreeDiff                 (Edit (..), EditExpr (..),
+                                                Expr (App), GToExpr,
                                                 ToExpr (..), exprDiff,
                                                 genericToExpr,
                                                 ppEditExprCompact, ppExpr)
+import qualified Data.TreeDiff.OMap            as OMap
 import           Data.TreeDiff.Pretty          (Pretty (..), ppEditExpr)
 
 import           GHC.Generics                  (Generic, Rep)
@@ -26,9 +36,11 @@ import           Prettyprinter.Render.Terminal (AnsiStyle,
                                                 Color (Green, Red, White),
                                                 color, colorDull)
 
+import           Text.Printf                   (printf)
+
+
 import qualified Test.Tasty.HUnit              as HUnit
 
-import           Data.Time                     (TimeOfDay, LocalTime)
 import           Theta.Target.LanguageQuoter   (Interpolable, toText)
 
 -- * Human-Readable Diffs
@@ -38,11 +50,36 @@ import           Theta.Target.LanguageQuoter   (Interpolable, toText)
 -- | Compare two values, failing with a human-readable diff if they
 -- differ.
 --
+-- This provides a better error message when used in QuickCheck than
+-- failing normally.
+--
 -- This should work for (most?) types with 'Generic' instances.
 assertDiff :: (Eq a, Generic a, GToExpr (Rep a), MonadFail m) => a -> a -> m ()
 assertDiff a b = when (a /= b) $
   let diff = exprDiff (genericToExpr a) (genericToExpr b) in
   fail $ show $ prettyEditExpr diff
+
+-- | Compare two values, failing with a __compact__ human-readable
+-- diff if they differ.
+assertCompactDiff :: (Eq a, Generic a, GToExpr (Rep a), MonadFail m) => a -> a -> m ()
+assertCompactDiff a b = when (a /= b) $
+  let diff = exprDiff (genericToExpr a) (genericToExpr b) in
+  fail $ show $ prettyEditExprCompact diff
+
+-- | Compare two values, failing with a human-readable diff if they
+-- differ. The human-readable diff will include only the first part of
+-- the two values that differs, with a trail of "breadcrumbs" to
+-- specify the location.
+--
+-- Useful for comparing two large values that differ in small parts.
+assertFirstDiff :: (Eq a, Generic a, GToExpr (Rep a), MonadFail m) => a -> a -> m ()
+assertFirstDiff a b = when (a /= b) $ do
+  let diff = exprDiff (genericToExpr a) (genericToExpr b)
+  fail $ case firstDifference diff of
+    Just (breadcrumbs, expr) ->
+      printf "%s\n\n%s" (show breadcrumbs) (show $ prettyEditExpr expr)
+    Nothing -> "<no difference>"
+
 
 -- | Compare two algebraic data types, generating a human-readable
 -- diff if they differ. This is the HUnit-specific version of
@@ -55,6 +92,43 @@ a ?=: b = when (a /= b) $
   HUnit.assertFailure $ show $ prettyEditExpr diff
 
 -- *** Diff Formatting
+
+-- | Find the first part of an 'Edit EditExpr' that's different: an
+-- insert, delete or swap but not a copy. This helps debug /really
+-- large/ diffs where finding the difference in the formatted output
+-- is difficult.
+--
+-- Return the part that is different along with a list of
+-- human-readable breadcrumbs (constructor names, field names, list
+-- indices) for locating the difference.
+--
+-- Returns 'Nothing' if the diff is entirely unchanged.
+firstDifference :: Edit EditExpr -> Maybe ([String], Edit EditExpr)
+firstDifference = fmap (first toList) . go []
+  where go breadcrumbs edit = case edit of
+          Ins{}  -> Just (breadcrumbs, edit)
+          Del{}  -> Just (breadcrumbs, edit)
+          Swp{}  -> Just (breadcrumbs, edit)
+
+          Cpy ee -> case ee of
+            EditApp constructor args   -> goValues (breadcrumbs |> constructor) args
+            EditRec constructor fields -> goFields (breadcrumbs |> constructor) fields
+            EditLst exps               -> goValues breadcrumbs exps
+            EditExp{}                  -> Nothing
+
+        goValues breadcrumbs args = do
+          i                   <- List.findIndex isJust differences
+          (breadcrumbs', exp) <- differences !! i
+          pure ((breadcrumbs |> show i) <> breadcrumbs', exp)
+          where differences = go breadcrumbs <$> args
+
+        goFields breadcrumbs (OMap.toList -> fields) = do
+          i <- List.findIndex isJust differences
+          (breadcrumbs', exp) <- differences !! i
+          pure (breadcrumbs <> breadcrumbs', exp)
+            where differences = fields <&> \ (fieldName, fieldExp) ->
+                    go (breadcrumbs |> fieldName) fieldExp
+
 
 -- | The tree-diff library is designed to work with different
 -- pretty-printing libraries. It does not have @prettyprinter@ support

--- a/theta/src/Theta/Value.hs
+++ b/theta/src/Theta/Value.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE NamedFieldPuns     #-}
+{-# LANGUAGE NumDecimals        #-}
 {-# LANGUAGE ParallelListComp   #-}
 {-# LANGUAGE ViewPatterns       #-}
 -- | This module defines the 'Value' type which is a generic
@@ -296,10 +297,11 @@ genValue' overrides = go
         genDate = Time.ModifiedJulianDay <$> arbitrary
         genDatetime = Time.UTCTime <$> genDate <*> genDiffTime
         genLocalTime = Time.LocalTime <$> genDate <*> genTimeOfDay
-        genDiffTime = Time.secondsToDiffTime <$> choose (0, maxSeconds)
+        genDiffTime = microsecondsToDiffTime <$> choose (0, maxMicroseconds)
         genTimeOfDay = Time.timeToTimeOfDay <$> genDiffTime
 
-        maxSeconds = 24 * 60 * 60 -- covers leap seconds
+        maxMicroseconds = (24 * 60 * 60 * 1e6) - 1 -- no leap seconds
+        microsecondsToDiffTime micros = Time.picosecondsToDiffTime  $ micros * 1e6
 
 -- | Generate values with the given type.
 --

--- a/theta/test/Test/Theta/Error.hs
+++ b/theta/test/Test/Theta/Error.hs
@@ -7,23 +7,23 @@
 {-# LANGUAGE TypeApplications      #-}
 module Test.Theta.Error where
 
-import           Control.Monad.Except (runExceptT)
+import           Control.Monad.Except  (runExceptT)
 
-import qualified Data.Algorithm.Diff  as Diff
-import qualified Data.Set             as Set
+import qualified Data.Algorithm.Diff   as Diff
+import qualified Data.Set              as Set
 
 import           Test.Tasty
-import           Test.Tasty.HUnit     (testCase, (@?=))
+import           Test.Tasty.HUnit      (testCase, (@?=))
 
-import           Test.Assertions      ((?=))
+import           Theta.Test.Assertions ((?=))
 
-import           Theta.Metadata       (Metadata (..))
-import           Theta.Pretty         (pr)
-import           Theta.Target.Haskell (loadModule)
-import           Theta.Types          (emptyModule)
+import           Theta.Metadata        (Metadata (..))
+import           Theta.Pretty          (pr)
+import           Theta.Target.Haskell  (loadModule)
+import           Theta.Types           (emptyModule)
 
 import           Theta.Error
-import           Theta.Import         (getModule)
+import           Theta.Import          (getModule)
 
 
 loadModule "test/data/modules" "importing_foo"

--- a/theta/test/Test/Theta/Target/Avro/Process.hs
+++ b/theta/test/Test/Theta/Target/Avro/Process.hs
@@ -16,9 +16,9 @@ import           Test.QuickCheck.Monadic         (monadicIO)
 import           Test.Tasty                      (TestTree, testGroup)
 import           Test.Tasty.QuickCheck           (forAll, listOf, testProperty)
 
-import           Test.Assertions                 (assertDiff)
-
 import qualified Streamly.Prelude                as Streamly
+
+import           Theta.Test.Assertions           (assertDiff)
 
 import           Theta.Pretty                    (Pretty (pretty))
 import           Theta.Target.Avro.Process       (run, stream)

--- a/theta/test/Test/Theta/Target/Kotlin.hs
+++ b/theta/test/Test/Theta/Target/Kotlin.hs
@@ -14,7 +14,8 @@ import           Theta.Target.Haskell            (loadModule)
 import           Theta.Target.Kotlin
 import           Theta.Target.Kotlin.QuasiQuoter
 
-import           Test.Assertions                 ((?=))
+import           Theta.Test.Assertions           ((?=))
+
 import           Test.Tasty
 import           Test.Tasty.HUnit
 

--- a/theta/test/Test/Theta/Target/Python.hs
+++ b/theta/test/Test/Theta/Target/Python.hs
@@ -20,6 +20,9 @@ import           System.FilePath         ((<.>), (</>))
 
 import           Text.Mustache           (compileMustacheFile, renderMustache)
 
+import           Test.Tasty
+import           Test.Tasty.HUnit
+
 import qualified Theta.Error             as Theta
 import           Theta.Metadata          (Metadata (..))
 import qualified Theta.Pretty            as Theta
@@ -29,10 +32,7 @@ import           Theta.Target.Python
 import qualified Theta.Types             as Theta
 import qualified Theta.Versions          as Theta
 
-import           Test.Tasty
-import           Test.Tasty.HUnit
-
-import           Test.Assertions         ((?=))
+import           Theta.Test.Assertions   ((?=))
 
 import qualified Paths_theta             as Paths
 

--- a/theta/test/Test/Theta/Target/Rust.hs
+++ b/theta/test/Test/Theta/Target/Rust.hs
@@ -22,11 +22,10 @@ import           Theta.Target.Rust
 import           Theta.Target.Rust.QuasiQuoter (normalize)
 import qualified Theta.Types                   as Theta
 
+import           Theta.Test.Assertions         ((?=))
+
 import           Test.Tasty
 import           Test.Tasty.HUnit
-
-
-import           Test.Assertions               ((?=))
 
 import qualified Paths_theta                   as Paths
 

--- a/theta/theta.cabal
+++ b/theta/theta.cabal
@@ -64,6 +64,7 @@ common shared
                , tasty-hunit
                , th-lift-instances ==0.1.*
                , time
+               , tree-diff >=0.2 && <0.3
                , unordered-containers
                , uuid ==1.3.*
                , vector
@@ -110,14 +111,14 @@ library
                     , Theta.Target.Rust
                     , Theta.Target.Rust.QuasiQuoter
 
+                    , Theta.Test.Assertions
+
 test-suite tests
   import:             shared
   type:               exitcode-stdio-1.0
   main-is:            Test.hs
   hs-source-dirs:     test
-  other-modules:      Test.Assertions
-                      
-                    , Test.Theta.Error
+  other-modules:      Test.Theta.Error
                     , Test.Theta.Import
                     , Test.Theta.LoadPath
                     , Test.Theta.Name
@@ -147,10 +148,7 @@ test-suite tests
 
   build-depends:      theta
 
-                    , directory
                     , stache >=2.3.1 && <3
-                    , tree-diff >=0.2 && <0.3
-
                     , tasty
                     , tasty-golden
                     , tasty-hunit
@@ -161,7 +159,6 @@ executable theta
   hs-source-dirs:     apps/
   build-depends:      theta
 
-                    , directory
                     , optparse-applicative
 
   main-is:            Theta.hs


### PR DESCRIPTION
The initial implementation of `Time` did not handle leap seconds consistently across languages. `23:59:60` would work in Haskell but get read as `00:00:00` in Rust and Python.

Since Python's `datetime` package [does not handle leap seconds at all][1] and leap seconds are, in general, a massive headache, I am going to explicitly *not* support leap seconds in Theta. Theta will never *write* a leap second to a `Time` value and it will *read* `Time` values with a leap second as `23:59:59.999999`.

This PR adds leap-second-handling logic to Haskell, Python and Rust along with tests.

I originally caught the bug when one the cross-language QuickCheck tests failed with a *massive* input. To help debug this, I moved `Test.Assertions` from a hidden module in Theta's test suite to `Theta.Test.Assertions` and wrote a version of `assertDiff` that only prints the first difference between two values (rather than the whole thing). This made finding the part of the test case that caused the failure a lot easier than needing to deal with the *entire* input!

[1]: https://docs.python.org/3/library/datetime.html#available-types