### PR TITLE
Fixed-size types

### DIFF
--- a/test/cross-language/modules/primitives.theta
+++ b/test/cross-language/modules/primitives.theta
@@ -15,7 +15,10 @@ type Primitives = {
   datetime       : Datetime,
   uuid           : UUID,
   time           : Time,
-  local_datetime : LocalDatetime
+  local_datetime : LocalDatetime,
+  fixed_0        : Fixed(0),
+  fixed_10       : Fixed(10),
+  fixed_10_again : Fixed(10)
 }
 
 /// Each kind of container:

--- a/test/cross-language/test/Test/Primitives.hs
+++ b/test/cross-language/test/Test/Primitives.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DeriveAnyClass        #-}
 {-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE DerivingStrategies    #-}

--- a/test/python/modules/primitives.theta
+++ b/test/python/modules/primitives.theta
@@ -16,7 +16,9 @@ type Primitives = {
   datetime : Datetime,
   uuid : UUID, // language-version ≥ 1.1.0
   time : Time, // language-version ≥ 1.1.0
-  local_datetime : LocalDatetime // language-version ≥ 1.1.0
+  local_datetime : LocalDatetime, // language-version ≥ 1.1.0
+  fixed_1 : Fixed(1), // language-version ≥ 1.1.0
+  fixed_3 : Fixed(3) // language-version ≥ 1.1.0
 }
 
 // A record with the various kinds of containers Theta supports.

--- a/test/python/theta_python_tests/test_python.py
+++ b/test/python/theta_python_tests/test_python.py
@@ -44,7 +44,9 @@ primitives = builds(Primitives,
                     datetimes(),
                     uuids(),
                     times(),
-                    datetimes())
+                    datetimes(),
+                    binary(min_size=1, max_size=1),
+                    binary(min_size=3, max_size=3))
 
 containers = builds(Containers,
                     lists(booleans()),

--- a/test/rust/modules/primitives.theta
+++ b/test/rust/modules/primitives.theta
@@ -16,7 +16,9 @@ type Primitives = {
   datetime : Datetime,
   uuid : UUID, // language-version ≥ 1.1.0
   time : Time, // language-version ≥ 1.1.0
-  local_datetime : LocalDatetime // language-version ≥ 1.1.0
+  local_datetime : LocalDatetime, // language-version ≥ 1.1.0
+  fixed_1 : Fixed(1), // language-version ≥ 1.1.0
+  fixed_3 : Fixed(3) // language-version ≥ 1.1.0
 }
 
 // A record with the various kinds of containers Theta supports.

--- a/test/rust/src/lib.rs
+++ b/test/rust/src/lib.rs
@@ -17,7 +17,7 @@ mod tests {
 
     use std::collections::HashMap;
 
-    use theta::avro::{FromAvro, ToAvro};
+    use theta::avro::{FromAvro, ToAvro, Fixed};
 
     use super::enums::*;
     use super::rust::*;
@@ -42,6 +42,8 @@ mod tests {
             uuid: Uuid::from_str("f81d4fae-7dec-11d0-a765-00a0c91e6bf6").unwrap(),
             time: NaiveTime::from_hms(12, 23, 10),
             local_datetime: NaiveDate::from_ymd(10, 11, 12).and_hms(5, 0, 0),
+            fixed_1: Fixed(vec![0xC0]),
+            fixed_3: Fixed(vec![0xC0, 0xFF, 0xEE]),
         };
         assert!(check_encoding(example));
     }
@@ -131,6 +133,8 @@ mod tests {
             uuid: Uuid::from_str("f81d4fae-7dec-11d0-a765-00a0c91e6bf6").unwrap(),
             time: NaiveTime::from_hms(12, 23, 10),
             local_datetime: NaiveDate::from_ymd(10, 11, 12).and_hms(5, 0, 0),
+            fixed_1: Fixed(vec![0xC0]),
+            fixed_3: Fixed(vec![0xC0, 0xFF, 0xEE]),
         };
         let shadowing_record = shadowing::shadowing::Primitives {
             underlying: shadowed_record.clone(),

--- a/theta/src/Theta/Fixed.hs
+++ b/theta/src/Theta/Fixed.hs
@@ -1,0 +1,106 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE DerivingStrategies  #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE MonadComprehensions #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+
+module Theta.Fixed
+  ( FixedBytes
+  , toByteString
+
+  , fixedBytes
+  , fixedBytes'
+  , size
+  , sizeOf
+  )
+where
+
+import qualified Data.ByteString.Lazy as LBS
+import           Data.Data            (Proxy (Proxy))
+import           Data.Maybe           (fromMaybe)
+import qualified Data.Text            as Text
+import           Data.TreeDiff        (Expr (App), ToExpr (toExpr))
+
+import           GHC.TypeLits         (KnownNat, Nat, natVal)
+
+import           Text.Printf          (printf)
+
+import           Theta.Pretty         (Pretty (pretty))
+
+-- | A bytestring with a size specified at the type level.
+--
+-- The @size@ should always be the same as the length of the
+-- underlying bytestring, otherwise the behavior of the type is
+-- unspecified.
+newtype FixedBytes (size :: Nat) = FixedBytes { toByteString :: LBS.ByteString }
+  deriving stock (Eq)
+
+instance KnownNat size => Show (FixedBytes size) where
+  show fixed = printf "FixedBytes @%d %s" (sizeOf fixed) (show $ toByteString fixed)
+
+instance Pretty (FixedBytes size) where
+  pretty (FixedBytes bytes) = Text.pack $ show bytes
+
+instance KnownNat size => ToExpr (FixedBytes size) where
+  toExpr t = App "FixedBytes" [toExpr $ show t]
+
+-- | Wrap a bytestring into a 'FixedBytes' with a set size.
+--
+-- Returns 'Nothing' if the length of the bytestring does not match
+-- the statically expected size.
+--
+-- When the @size@ type variable cannot be inferred, you can specify
+-- it with type applications:
+--
+-- >>> fixedBytes @3 "abc"
+-- Just (FixedBytes {toByteString = "abc"})
+--
+-- >>> fixedBytes @4 "abc"
+-- Nothing
+--
+fixedBytes :: forall size. KnownNat size => LBS.ByteString -> Maybe (FixedBytes size)
+fixedBytes bytes = [FixedBytes bytes | LBS.length bytes == size]
+  where size = fromIntegral $ natVal (Proxy @size)
+
+-- | Wrap a bytestring into a 'FixedBytes' with a set size.
+--
+-- Errors at runtime if the bytestring's length does not match the
+-- expected size.
+--
+-- When the @size@ type variable cannot be inferred, you can specify
+-- it with type applications:
+--
+-- >>> fixedBytes' @3 "abc"
+-- FixedBytes {toByteString = "abc"}
+--
+-- >>> fixedBytes' @4 "abc"
+-- fixedBytes expected 4 bytes but got a bytestring of length 3.
+--
+fixedBytes' :: forall size. KnownNat size => LBS.ByteString -> FixedBytes size
+fixedBytes' bytes = fromMaybe failure $ fixedBytes bytes
+  where failure = error $ printf
+          "fixedBytes expected %d bytes but got a bytestring of length %d" expected got
+        expected = natVal (Proxy @size)
+        got = LBS.length bytes
+
+-- | The runtime size that corresponds to a type-level size.
+--
+-- The @size@ type variable will always be ambiguous, so this is meant
+-- to be used with visible type applications:
+--
+-- >>> size @10
+-- 10
+--
+size :: forall size. KnownNat size => Word
+size = fromIntegral $ natVal (Proxy @size)
+
+-- | The statically specified size of the given 'FixedBytes' value.
+--
+-- >>> sizeOf (fixedBytes' @3 "abc")
+-- 3
+--
+sizeOf :: forall size. KnownNat size => FixedBytes size -> Word
+sizeOf _ = size @size

--- a/theta/src/Theta/Hash.hs
+++ b/theta/src/Theta/Hash.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings          #-}
-{-# LANGUAGE TemplateHaskell            #-}
+{-# LANGUAGE TemplateHaskellQuotes      #-}
 -- | Theta types carry a unique, structural hash for quick equality
 -- comparisons.
 --

--- a/theta/src/Theta/Metadata.hs
+++ b/theta/src/Theta/Metadata.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveLift                 #-}
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE TemplateHaskell            #-}
+{-# LANGUAGE TemplateHaskellQuotes      #-}
 {-# LANGUAGE ViewPatterns               #-}
 
 -- | This module defines types for handling version metadata in Theta

--- a/theta/src/Theta/Name.hs
+++ b/theta/src/Theta/Name.hs
@@ -27,8 +27,11 @@ import           Language.Haskell.TH.Syntax (Lift)
 import           Test.QuickCheck            (Arbitrary (..))
 import qualified Test.QuickCheck            as QuickCheck
 
+import           Text.Printf                (printf)
+
 import           Theta.Hash                 (Hash, hashList, hashText)
-import           Theta.Pretty               (Pretty (..), ShowPretty (..))
+import           Theta.Pretty               (Pretty (..), ShowPretty (..),
+                                             showPretty)
 
 -- * Definitions
 
@@ -50,7 +53,8 @@ data Name = Name { moduleName :: ModuleName
                  }
   deriving stock (Eq, Ord, Generic, Lift)
   deriving anyclass (Hashable)
-  deriving Show via ShowPretty Name
+
+instance Show Name where show = printf "\"%s\"" . showPretty
 
 -- | Parses string literals as dot-sperated names.
 --
@@ -137,7 +141,7 @@ parse' (Text.splitOn "." -> components)
         valid part = first (Text.head part) && rest (Text.tail part)
 
         first x = Char.isLetter x || x == '_'
-        rest xs = Text.all (\ x -> Char.isAlphaNum x || x == '_') xs
+        rest = Text.all (\ x -> Char.isAlphaNum x || x == '_')
 
 -- | Parse a text representation of a 'Name'.
 --

--- a/theta/src/Theta/Target/Avro/Error.hs
+++ b/theta/src/Theta/Target/Avro/Error.hs
@@ -96,6 +96,9 @@ data AvroError = InvalidExport Type
                | InvalidUUID Text
                  -- ^ A string encoding a UUID did not have the right
                  -- format.
+               | FixedSizeMismatch Int Int
+                 -- ^ A mismatch between the size of fixed type that
+                 -- was expected and the size that was read.
                deriving (Show)
 
 -- | The reason why a variant encoding is invalid.
@@ -166,6 +169,11 @@ instance Pretty AvroError where
 
         Example: ‘f81d4fae-7dec-11d0-a765-00a0c91e6bf6’
         |]
+    FixedSizeMismatch expected got ->
+     [p|
+       Expected a fixed-size type of #{expected} bytes
+       But got #{got} bytes
+       |]
 
 -- | Render a human-readable description of why a varaint was not
 -- encoded correctly.

--- a/theta/src/Theta/Target/Haskell.hs
+++ b/theta/src/Theta/Target/Haskell.hs
@@ -93,17 +93,18 @@ import qualified Language.Haskell.TH             as TH
 import qualified Language.Haskell.TH.Syntax      as TH
 
 import           Theta.Error                     (Error)
+import           Theta.Fixed                     (FixedBytes)
 import qualified Theta.Import                    as Import
 import           Theta.Metadata                  (Metadata (..))
 import qualified Theta.Name                      as Name
 import qualified Theta.Pretty                    as Theta
+import qualified Theta.Primitive                 as Primitive
 import qualified Theta.Types                     as Theta
 import qualified Theta.Value                     as Theta
 
 import           Theta.Target.Avro.Types         (typeToAvro)
 import qualified Theta.Target.Avro.Values        as Theta
 
-import qualified Theta.Primitive                 as Primitive
 import qualified Theta.Target.Haskell.Conversion as Conversion
 import           Theta.Target.Haskell.HasTheta   (HasTheta (..))
 
@@ -266,6 +267,8 @@ generateThetaExp type_ = case Theta.baseType type_ of
     Primitive.UUID          -> [e| Theta.uuid' |]
     Primitive.Time          -> [e| Theta.time' |]
     Primitive.LocalDatetime -> [e| Theta.localDatetime' |]
+
+  Theta.Fixed' size         -> [e| Theta.fixed' size |]
 
   Theta.Array' type_        -> [e| Theta.array' $(generateThetaExp type_) |]
   Theta.Map' type_          -> [e| Theta.map' $(generateThetaExp type_) |]
@@ -1192,6 +1195,10 @@ generateType type_ = case Theta.baseType type_ of
     Primitive.UUID          -> [t| UUID |]
     Primitive.Time          -> [t| TimeOfDay |]
     Primitive.LocalDatetime -> [t| LocalTime |]
+
+  Theta.Fixed' size ->
+    let sizeType = TH.litT $ TH.numTyLit $ fromIntegral size in
+    [t| FixedBytes $sizeType |]
 
   Theta.Array' items    -> [t| [$(generateType items)] |]
   Theta.Map' values     -> [t| HashMap Text $(generateType values) |]

--- a/theta/src/Theta/Target/Haskell/HasTheta.hs
+++ b/theta/src/Theta/Target/Haskell/HasTheta.hs
@@ -17,6 +17,10 @@ import           Data.Text            (Text)
 import           Data.Time            (Day, LocalTime, TimeOfDay, UTCTime)
 import           Data.UUID            (UUID)
 
+import           GHC.TypeLits         (KnownNat)
+
+import           Theta.Fixed          (FixedBytes)
+import qualified Theta.Fixed          as Fixed
 import qualified Theta.Types          as Theta
 
 -- | A class for Haskell types that correspond to a Theta type. Types
@@ -66,6 +70,9 @@ instance HasTheta TimeOfDay where
 
 instance HasTheta LocalTime where
   theta = Theta.localDatetime'
+
+instance KnownNat size => HasTheta (FixedBytes size) where
+  theta = Theta.fixed' $ Fixed.size @size
 
 instance HasTheta a => HasTheta [a] where
   theta = Theta.array' $ theta @a

--- a/theta/src/Theta/Target/Kotlin.hs
+++ b/theta/src/Theta/Target/Kotlin.hs
@@ -191,6 +191,8 @@ toReference Theta.Type { Theta.baseType } = case baseType of
     Theta.Time          -> "LocalTime"
     Theta.LocalDatetime -> "LocalDateTime"
 
+  Theta.Fixed' _ -> "ByteArray"
+
   -- containers
   Theta.Array' a        -> let items = toReference a in [kotlin|Array<$items>|]
   Theta.Map' a          -> let values = toReference a in

--- a/theta/test/Test/Theta/Target/Avro/Process.hs
+++ b/theta/test/Test/Theta/Target/Avro/Process.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE LambdaCase            #-}

--- a/theta/test/Test/Theta/Target/Haskell.hs
+++ b/theta/test/Test/Theta/Target/Haskell.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE LambdaCase            #-}
@@ -25,6 +26,7 @@ import qualified Data.Text                       as Text
 import qualified Data.UUID                       as UUID
 import qualified Data.Vector                     as Vector
 
+import qualified Theta.Fixed                     as Fixed
 import           Theta.Metadata                  (Metadata (..))
 import           Theta.Pretty                    (pretty)
 import           Theta.Types
@@ -67,8 +69,21 @@ test_primitives = testGroup "primitives"
   , testCase "fromAvro ∘ toAvro = id" $ do
       Avro.decodeValue (Avro.encodeValue primitives) @?= Right primitives
   ]
-  where primitives =
-          Primitives True "blarg" 37 42 1.2 7.4 "foo" today now uuid time localTime
+  where primitives = Primitives
+          { bool = True
+          , bytes = "blarg"
+          , int = 37
+          , long = 42
+          , float = 1.2
+          , double = 7.4
+          , string = "foo"
+          , date = today
+          , datetime = now
+          , uuid = uuid
+          , time = time
+          , local_datetime = localTime
+          , fixed_3 = Fixed.fixedBytes' "abc"
+          }
         expected = Theta.Record
           [ Theta.boolean True
           , Theta.bytes "blarg"
@@ -82,6 +97,7 @@ test_primitives = testGroup "primitives"
           , Theta.uuid uuid
           , Theta.time time
           , Theta.localDatetime localTime
+          , Theta.fixed "abc"
           ]
 
         today = read "2019-02-11"

--- a/theta/test/Test/Theta/Target/Kotlin.hs
+++ b/theta/test/Test/Theta/Target/Kotlin.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE OverloadedLists       #-}
@@ -51,13 +52,19 @@ test_isValidIdentifier = testGroup "isValidIdentifier"
 test_toReference :: TestTree
 test_toReference = testGroup "toReference"
   [ testCase "primitive types" $ do
-      toReference Theta.bool'   @?= [kotlin|Boolean|]
-      toReference Theta.bytes'  @?= [kotlin|ByteArray|]
-      toReference Theta.int'    @?= [kotlin|Int|]
-      toReference Theta.long'   @?= [kotlin|Long|]
-      toReference Theta.float'  @?= [kotlin|Float|]
-      toReference Theta.double' @?= [kotlin|Double|]
-      toReference Theta.string' @?= [kotlin|String|]
+      toReference Theta.bool'          @?= [kotlin|Boolean|]
+      toReference Theta.bytes'         @?= [kotlin|ByteArray|]
+      toReference Theta.int'           @?= [kotlin|Int|]
+      toReference Theta.long'          @?= [kotlin|Long|]
+      toReference Theta.float'         @?= [kotlin|Float|]
+      toReference Theta.double'        @?= [kotlin|Double|]
+      toReference Theta.string'        @?= [kotlin|String|]
+      toReference Theta.date'          @?= [kotlin|LocalDate|]
+      toReference Theta.datetime'      @?= [kotlin|OffsetDateTime|]
+      toReference Theta.uuid'          @?= [kotlin|UUID|]
+      toReference Theta.time'          @?= [kotlin|LocalTime|]
+      toReference Theta.localDatetime' @?= [kotlin|LocalDateTime|]
+      toReference (Theta.fixed' 10)    @?= [kotlin|ByteArray|]
 
   , testCase "containers" $ do
       toReference (Theta.array' Theta.int')       @?= [kotlin|Array<Int>|]

--- a/theta/test/Test/Theta/Target/Python.hs
+++ b/theta/test/Test/Theta/Target/Python.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts      #-}
@@ -52,13 +53,19 @@ tests = testGroup "Python"
 test_toReference :: TestTree
 test_toReference = testGroup "toReference"
   [ testCase "primitive types" $ do
-      toReference' "base" Theta.bool'   ?= [python|bool|]
-      toReference' "base" Theta.bytes'  ?= [python|bytes|]
-      toReference' "base" Theta.int'    ?= [python|int|]
-      toReference' "base" Theta.long'   ?= [python|int|]
-      toReference' "base" Theta.float'  ?= [python|float|]
-      toReference' "base" Theta.double' ?= [python|float|]
-      toReference' "base" Theta.string' ?= [python|str|]
+      toReference' "base" Theta.bool'          ?= [python|bool|]
+      toReference' "base" Theta.bytes'         ?= [python|bytes|]
+      toReference' "base" Theta.int'           ?= [python|int|]
+      toReference' "base" Theta.long'          ?= [python|int|]
+      toReference' "base" Theta.float'         ?= [python|float|]
+      toReference' "base" Theta.double'        ?= [python|float|]
+      toReference' "base" Theta.string'        ?= [python|str|]
+      toReference' "base" Theta.date'          ?= [python|date|]
+      toReference' "base" Theta.datetime'      ?= [python|datetime|]
+      toReference' "base" Theta.uuid'          ?= [python|UUID|]
+      toReference' "base" Theta.time'          ?= [python|time|]
+      toReference' "base" Theta.localDatetime' ?= [python|datetime|]
+      toReference' "base" (Theta.fixed' 10)    ?= [python|bytes|]
 
   , testCase "containers" $ do
       toReference' "base" (Theta.array' Theta.int')       ?= [python|List[int]|]

--- a/theta/test/Test/Theta/Types.hs
+++ b/theta/test/Test/Theta/Types.hs
@@ -69,8 +69,10 @@ test_eq = testGroup "Eq instance"
         assertBool message (s /= t)
   ]
   where basicTypes = Theta.primitiveTypes <> structuredTypes
-        structuredTypes = 
-          [ Theta.array' Theta.int'
+        structuredTypes =
+          [ Theta.fixed' 3
+
+          , Theta.array' Theta.int'
           , Theta.map' Theta.int'
           , Theta.optional' Theta.int'
 
@@ -92,6 +94,7 @@ test_eq = testGroup "Eq instance"
         checkType type_ = case Theta.baseType type_ of
           -- primitive types
           Theta.Primitive'{} -> type_ @?= type_
+          Theta.Fixed'{}     -> type_ @?= type_
 
           -- containers
           Theta.Array'{}     -> type_ @?= type_
@@ -228,6 +231,11 @@ test_hashing = testGroup "hashing"
             test name t =
               testCase name (Theta.wrapPrimitive t ?= expectedPrimitive t)
         in [ test (show t) t | t <- primitives ]
+
+    , testGroup "Fixed"
+      [ testCase "Fixed(0)"   $ Theta.fixed' 0 ?= "00d0ceea6bfadb90cbcb4a30a5c7ae48"
+      , testCase "Fixed(100)" $ Theta.fixed' 100 ?= "c63c2d52afcfcdebcc556492971f9ea4"
+      ]
 
     , testGroup "container"
       [ testCase "[Bool]" $ Theta.array' Theta.bool' ?= "a923b66caa3b5848189d5f889979bd36"

--- a/theta/test/Test/Theta/Value.hs
+++ b/theta/test/Test/Theta/Value.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE OverloadedLists       #-}
@@ -33,6 +34,10 @@ tests = testGroup "Value"
   [ testProperty "primitive types" $ do
       values <- mapM genValue primitiveTypes
       pure $ all checkValue values
+
+  , testProperty "Fixed(10)" $ do
+      value <- genValue (Theta.fixed' 10)
+      pure $ checkValue value && type_ value == Theta.fixed' 10
 
   , testProperty "primitives.Primitives" $ do
       value <- genValue (theta @Primitives)

--- a/theta/test/data/modules/fixed.theta
+++ b/theta/test/data/modules/fixed.theta
@@ -1,0 +1,19 @@
+language-version: 1.1.0
+avro-version: 1.0.0
+---
+
+/// A record with two fields with the same Fixed(·) type.
+///
+/// Multiple occurences of the same Fixed(·) type need special
+/// treatment in Avro since fixed types need to have names.
+type MultiFixed = {
+    fixed_a : Fixed(3), // should define a new type named theta.fixed.Fixed_3
+    fixed_b : Fixed(3), // should be a reference to theta.fixed.Fixed_3
+    fixed_4: Fixed(4),  // should define a new type
+    nested_fixed : NestedFixed
+}
+
+type NestedFixed = {
+    // this one should also just be a reference to theta.fixed.Fixed_3
+    fixed_c : Fixed(3)
+}

--- a/theta/test/data/modules/primitives.theta
+++ b/theta/test/data/modules/primitives.theta
@@ -16,7 +16,8 @@ type Primitives = {
   datetime : Datetime,
   uuid : UUID,
   time : Time,
-  local_datetime : LocalDatetime
+  local_datetime : LocalDatetime,
+  fixed_3 : Fixed(3)
 }
 
 type Containers = {

--- a/theta/test/data/modules/rust.theta
+++ b/theta/test/data/modules/rust.theta
@@ -1,4 +1,4 @@
-language-version: 1.0.0
+language-version: 1.1.0
 avro-version: 1.0.0
 ---
 
@@ -7,6 +7,12 @@ avro-version: 1.0.0
 type Foo = {
   input: Int,
   nested: [A]
+}
+
+/// Fixed(n) types require special handling in the Rust codegen
+type FixedFields = {
+    f_1: Fixed(1),
+    f_10: Fixed(10)
 }
 
 alias A = [Long]

--- a/theta/test/data/rust/enums.rs
+++ b/theta/test/data/rust/enums.rs
@@ -1,6 +1,6 @@
 use chrono::{Date, DateTime, NaiveDateTime, NaiveTime, Utc};
 use std::collections::HashMap;
-use theta::avro::{FromAvro, ToAvro};
+use theta::avro::{FromAvro, ToAvro, Fixed};
 use nom::{IResult, Err, error::{context, ErrorKind}};
 use uuid::{Uuid};
 

--- a/theta/test/data/rust/newtype.rs
+++ b/theta/test/data/rust/newtype.rs
@@ -1,6 +1,6 @@
 use chrono::{Date, DateTime, NaiveDateTime, NaiveTime, Utc};
 use std::collections::HashMap;
-use theta::avro::{FromAvro, ToAvro};
+use theta::avro::{FromAvro, ToAvro, Fixed};
 use nom::{IResult, Err, error::{context, ErrorKind}};
 use uuid::{Uuid};
 

--- a/theta/test/data/rust/recursive.rs
+++ b/theta/test/data/rust/recursive.rs
@@ -1,6 +1,6 @@
 use chrono::{Date, DateTime, NaiveDateTime, NaiveTime, Utc};
 use std::collections::HashMap;
-use theta::avro::{FromAvro, ToAvro};
+use theta::avro::{FromAvro, ToAvro, Fixed};
 use nom::{IResult, Err, error::{context, ErrorKind}};
 use uuid::{Uuid};
 

--- a/theta/test/data/rust/single_file.rs
+++ b/theta/test/data/rust/single_file.rs
@@ -7,7 +7,7 @@ pub mod newtype {
 
     use chrono::{Date, DateTime, NaiveDateTime, NaiveTime, Utc};
     use std::collections::HashMap;
-    use theta::avro::{FromAvro, ToAvro};
+    use theta::avro::{FromAvro, ToAvro, Fixed};
     use nom::{IResult, Err, error::{context, ErrorKind}};
     use uuid::{Uuid};
 
@@ -56,7 +56,7 @@ pub mod recursive {
 
     use chrono::{Date, DateTime, NaiveDateTime, NaiveTime, Utc};
     use std::collections::HashMap;
-    use theta::avro::{FromAvro, ToAvro};
+    use theta::avro::{FromAvro, ToAvro, Fixed};
     use nom::{IResult, Err, error::{context, ErrorKind}};
     use uuid::{Uuid};
 

--- a/theta/theta.cabal
+++ b/theta/theta.cabal
@@ -79,6 +79,7 @@ library
   hs-source-dirs:     src/
 
   exposed-modules:    Theta.Error
+                    , Theta.Fixed
                     , Theta.Hash
                     , Theta.Import
                     , Theta.LoadPath


### PR DESCRIPTION
This PR adds support for fixed-size types for `language-version ≥ 1.1.0`. A fixed-size type is like a bytestring with a statically known size: `Fixed(3)` is always 3 bytes, `Fixed(10)` is always 10 bytes... etc.

In Avro, fixed types have names. This didn't really make sense for Theta, so Theta uses a canonical set of names when generating fixed types in Avro schemas: `Fixed(3)` becomes `theta.fixed.Fixed_3`, `Fixed(10)` becomes `theta.fixed.Fixed_10`... etc.

In Haskell, we use a type-level natural number to track the size of each field:

``` haskell
{-# LANGUAGE DataKinds #-}

import Theta.Fixed (FixedBytes)

data Example = Example
  { fixed_1  :: FixedBytes 1
  , fixed_10 :: FixedBytes 10
  }
```

In Rust and Python the sizes are specified during code generation and we don't track them at the type level.