### PR TITLE
Remove aeson-qq dependency

### DIFF
--- a/theta/theta.cabal
+++ b/theta/theta.cabal
@@ -35,7 +35,6 @@ common shared
 
                , aeson
                , aeson-pretty >=0.8.9 && <0.9
-               , aeson-qq
                , avro >=0.6 && <0.7
                , binary
                , bytestring


### PR DESCRIPTION
`aeson-qq` is one of the two packages that depends on `haskell-src-exts` and it looks like I'm not actually using it in the code anywhere.

This is the first (and much smaller!) PR for #67