### PR TITLE
Switched from string-interpolate to PyF

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,7 @@
           avro = "0.6.0.1";
           hashable = "1.4.0.2";
           OneTuple = "0.3.1";
+          PyF = "0.10.2.0";
           quickcheck-instances = "0.3.27";
           semialign = "1.2.0.1";
           stache = "2.3.1";

--- a/theta/apps/Apps/Avro.hs
+++ b/theta/apps/Apps/Avro.hs
@@ -12,17 +12,17 @@ import           Control.Monad.IO.Class  (liftIO)
 
 import qualified Data.Aeson              as Aeson
 import qualified Data.ByteString.Lazy    as LBS
-import           Data.String.Interpolate (__i)
 import qualified Data.Text               as Text
 
 import           Options.Applicative
 
 import           System.Directory        (createDirectoryIfMissing)
-import           System.FilePath         ((<.>), (</>), joinPath)
+import           System.FilePath         (joinPath, (<.>), (</>))
 
 import qualified Theta.Import            as Theta
 import           Theta.Name              (ModuleName, Name (..))
 import qualified Theta.Name              as Name
+import           Theta.Pretty            (pr)
 import           Theta.Target.Avro.Types (toSchema)
 import qualified Theta.Types             as Theta
 
@@ -40,7 +40,7 @@ avroCommand = command "avro" opts
           [ typeCommand, allCommand ]
 
 avroDescription :: String
-avroDescription = [__i|
+avroDescription = [pr|
   Commands for working with Avro schemas generate from Theta types.
 |]
 
@@ -97,7 +97,7 @@ allCommand = command "all" $ runAll <$> opts
           (fullDesc <> progDesc allDescription)
 
 allDescription :: String
-allDescription = [__i|
+allDescription = [pr|
   Compile every exportable type from the given module and every module
   it (transitively) imports to an Avro schema, placing all the schemas
   in $TARGET_DIRECTORY/avro.
@@ -121,7 +121,7 @@ runAll AllOptions { target, moduleNames } loadPath = do
     forM_ (Theta.types module_) $ \ definition ->
       export (Theta.moduleName module_) definition
 
-  where 
+  where
       export moduleName definition = do
         schema <- toSchema definition
         liftIO $ do

--- a/theta/apps/Apps/Hash.hs
+++ b/theta/apps/Apps/Hash.hs
@@ -7,17 +7,16 @@
 
 module Apps.Hash where
 
-import           Control.Monad           (forM_, unless)
-import           Control.Monad.IO.Class  (liftIO)
-
-import           Data.String.Interpolate (i)
+import           Control.Monad          (forM_, unless)
+import           Control.Monad.IO.Class (liftIO)
 
 import           Options.Applicative
 
-import qualified Theta.Import            as Theta
-import           Theta.Name              (ModuleName, Name (..))
-import qualified Theta.Name              as Name
-import qualified Theta.Types             as Theta
+import qualified Theta.Import           as Theta
+import           Theta.Name             (ModuleName, Name (..))
+import qualified Theta.Name             as Name
+import           Theta.Pretty           (pr)
+import qualified Theta.Types            as Theta
 
 import           Apps.Subcommand
 
@@ -48,15 +47,15 @@ hashTypes types loadPath = forM_ types $ \ typeName -> do
 
            -- Note the tab character
   let hash = Theta.hash . Theta.definitionType
-  liftIO $ putStrLn [i|#{Name.render typeName}	#{hash definition}|]
+  liftIO $ putStrLn [pr|{Name.render typeName}	{show $ hash definition}|]
 
 hashModules :: [ModuleName] -> Subcommand
 hashModules moduleNames loadPath = do
   modules <- traverse (Theta.getModule loadPath) moduleNames
 
-  forM_ (Theta.transitiveImports modules) $ \ module_ -> 
+  forM_ (Theta.transitiveImports modules) $ \ module_ ->
     forM_ (Theta.types module_) $ \ Theta.Definition
     { Theta.definitionType = type_, Theta.definitionName = name } ->
          -- Note the tab character
-    liftIO $ putStrLn [i|#{Name.render name}	#{Theta.hash type_}|]
+    liftIO $ putStrLn [pr|{Name.render name}	{show $ Theta.hash type_}|]
 

--- a/theta/apps/Apps/Kotlin.hs
+++ b/theta/apps/Apps/Kotlin.hs
@@ -2,30 +2,29 @@
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes       #-}
-{-# LANGUAGE ViewPatterns      #-}
 module Apps.Kotlin where
 
-import           Control.Monad           (forM_)
-import           Control.Monad.Trans     (liftIO)
+import           Control.Monad       (forM_)
+import           Control.Monad.Trans (liftIO)
 
-import qualified Data.List               as List
-import           Data.Maybe              (fromMaybe)
-import           Data.String.Interpolate (__i)
-import qualified Data.Text               as Text
-import qualified Data.Text.IO            as Text
+import qualified Data.List           as List
+import           Data.Maybe          (fromMaybe)
+import qualified Data.Text           as Text
+import qualified Data.Text.IO        as Text
 
 import           Options.Applicative
 
-import           System.Directory        (createDirectoryIfMissing)
-import           System.FilePath         ((<.>), (</>), joinPath)
+import           System.Directory    (createDirectoryIfMissing)
+import           System.FilePath     (joinPath, (<.>), (</>))
 
-import qualified Theta.Import            as Theta
-import           Theta.Name              (ModuleName)
-import qualified Theta.Name              as Name
-import qualified Theta.Types             as Theta
+import qualified Theta.Import        as Theta
+import           Theta.Name          (ModuleName)
+import qualified Theta.Name          as Name
+import           Theta.Pretty        (pr)
+import qualified Theta.Types         as Theta
 
-import           Theta.Target.Kotlin     (Kotlin (..))
-import qualified Theta.Target.Kotlin     as Kotlin
+import           Theta.Target.Kotlin (Kotlin (..))
+import qualified Theta.Target.Kotlin as Kotlin
 
 import           Apps.Subcommand
 
@@ -36,7 +35,7 @@ kotlinCommand = command "kotlin" $ runKotlin <$> opts
           (fullDesc <> progDesc kotlinDescription)
 
 kotlinDescription :: String
-kotlinDescription = [__i|
+kotlinDescription = [pr|
   Compile a Theta module and its transitive imports to Kotlin modules.
 |]
 

--- a/theta/apps/Apps/List.hs
+++ b/theta/apps/Apps/List.hs
@@ -9,23 +9,22 @@
 --  * list all modules in the load path with @theta list modules@
 module Apps.List where
 
-import           Data.String.Interpolate (__i)
+import           Options.Applicative    (CommandFields, Mod, Parser, command,
+                                         fullDesc, help, helper, info, long,
+                                         progDesc, subparser, switch, (<**>))
 
-import           Options.Applicative     (CommandFields, Mod, Parser, command,
-                                          fullDesc, help, helper, info, long,
-                                          progDesc, subparser, switch, (<**>))
+import           Control.Monad          (forM_)
+import           Control.Monad.IO.Class (liftIO)
 
-import           Apps.Subcommand         (Subcommand)
+import           Data.Foldable          (Foldable (toList))
+import qualified Data.List              as List
 
-import           Control.Monad           (forM_)
-import           Control.Monad.IO.Class  (liftIO)
+import           Text.Printf            (printf)
 
-import           Text.Printf             (printf)
+import qualified Theta.LoadPath         as LoadPath
+import           Theta.Pretty           (pr, showPretty)
 
-import qualified Theta.LoadPath          as LoadPath
-import           Theta.Pretty            (showPretty)
-import qualified Data.List as List
-import Data.Foldable (Foldable(toList))
+import           Apps.Subcommand        (Subcommand)
 
 -- * list
 
@@ -38,7 +37,7 @@ listCommand = command "list" opts
         subcommands = subparser $ mconcat [ modulesCommand ]
 
 listDescription :: String
-listDescription = [__i|
+listDescription = [pr|
   Commands for listing available Theta objects.
   |]
 
@@ -61,7 +60,7 @@ runModules options@ModuleOptions { paths, names } loadPath
         | otherwise      -> putStrLn (showPretty moduleName)
 
 modulesDescription :: String
-modulesDescription = [__i|
+modulesDescription = [pr|
   List every Theta module available in the Theta load path:
 
     • list module names: `theta list modules` or `theta list modules --names`

--- a/theta/apps/Apps/Python.hs
+++ b/theta/apps/Apps/Python.hs
@@ -2,29 +2,28 @@
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes       #-}
-{-# LANGUAGE ViewPatterns      #-}
 module Apps.Python where
 
-import           Control.Monad           (forM_)
-import           Control.Monad.Trans     (liftIO)
+import           Control.Monad       (forM_)
+import           Control.Monad.Trans (liftIO)
 
-import qualified Data.List               as List
-import           Data.String.Interpolate (__i)
-import qualified Data.Text               as Text
-import qualified Data.Text.IO            as Text
+import qualified Data.List           as List
+import qualified Data.Text           as Text
+import qualified Data.Text.IO        as Text
 
 import           Options.Applicative
 
-import           System.Directory        (createDirectoryIfMissing)
-import           System.FilePath         ((<.>), (</>), joinPath)
+import           System.Directory    (createDirectoryIfMissing)
+import           System.FilePath     (joinPath, (<.>), (</>))
 
-import           Theta.Import            (getModule)
-import           Theta.Name              (ModuleName)
-import qualified Theta.Name              as Name
-import qualified Theta.Types             as Theta
+import           Theta.Import        (getModule)
+import           Theta.Name          (ModuleName)
+import qualified Theta.Name          as Name
+import qualified Theta.Types         as Theta
 
-import           Theta.Target.Python     (Python (..))
-import qualified Theta.Target.Python     as Python
+import           Theta.Pretty        (pr)
+import           Theta.Target.Python (Python (..))
+import qualified Theta.Target.Python as Python
 
 import           Apps.Subcommand
 
@@ -35,7 +34,7 @@ pythonCommand = command "python" $ runPython <$> parser
           (fullDesc <> progDesc pythonDescription)
 
 pythonDescription :: String
-pythonDescription = [__i|
+pythonDescription = [pr|
   Compile a Theta module and its transitive dependencies to Python modules.
 |]
 

--- a/theta/apps/Apps/Rust.hs
+++ b/theta/apps/Apps/Rust.hs
@@ -6,7 +6,6 @@ module Apps.Rust where
 
 import           Control.Monad.Except
 
-import           Data.String.Interpolate       (__i)
 import qualified Data.Text.IO                  as Text
 
 
@@ -16,6 +15,7 @@ import qualified Theta.Import                  as Theta
 import qualified Theta.Name                    as Theta
 import qualified Theta.Types                   as Theta
 
+import           Theta.Pretty                  (pr)
 import           Theta.Target.Rust             (toFile)
 import           Theta.Target.Rust.QuasiQuoter (Rust (..))
 
@@ -28,7 +28,7 @@ rustCommand = command "rust" $ runRust <$> opts
           (fullDesc <> progDesc rustDescription)
 
 rustDescription :: String
-rustDescription = [__i|
+rustDescription = [pr|
   Compile the given Theta modules and their transitive imports to Rust modules.
 |]
 

--- a/theta/apps/Apps/Subcommand.hs
+++ b/theta/apps/Apps/Subcommand.hs
@@ -3,23 +3,23 @@
 {-# LANGUAGE ViewPatterns #-}
 module Apps.Subcommand where
 
-import           Control.Monad.Except    (ExceptT, runExceptT)
+import           Control.Monad.Except (ExceptT, runExceptT)
 
-import           Data.String.Interpolate (i)
-import           Data.Text               (Text)
-import qualified Data.Text               as Text
-import qualified Data.Text.IO            as Text
+import           Data.Text            (Text)
+import qualified Data.Text            as Text
+import qualified Data.Text.IO         as Text
 
-import           System.Exit             (exitFailure)
-import           System.IO               (stderr)
+import           System.Exit          (exitFailure)
+import           System.IO            (stderr)
 
 import           Options.Applicative
 
-import           Theta.Error             (Error (..))
-import qualified Theta.Import            as Theta
-import           Theta.Name              (ModuleName, Name)
-import qualified Theta.Name              as Name
-import qualified Theta.Pretty            as Theta
+import           Theta.Error          (Error (..))
+import qualified Theta.Import         as Theta
+import           Theta.Name           (ModuleName, Name)
+import qualified Theta.Name           as Name
+import           Theta.Pretty         (pr)
+import qualified Theta.Pretty         as Theta
 
 type Subcommand = Theta.LoadPath -> ExceptT Error IO ()
 
@@ -56,7 +56,7 @@ targetDirectory target = strOption
   <> long "out"
   <> value "."
   <> metavar "TARGET_DIRECTORY"
-  <> help [i|"Where to create #{target} (default ‘.’)."|]
+  <> help [pr|"Where to create {target} (default ‘.’)."|]
   )
 
 modules :: Parser [ModuleName]

--- a/theta/apps/Theta.hs
+++ b/theta/apps/Theta.hs
@@ -1,30 +1,31 @@
-{-# LANGUAGE LambdaCase     #-}
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE QuasiQuotes    #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes       #-}
 module Main where
 
-import           Data.String.Interpolate (__i, i)
-import qualified Data.Text.IO            as Text
+import qualified Data.Text.IO        as Text
 
-import           GHC.Exts                (fromString)
-import qualified GHC.IO.Encoding         as Encoding
+import           GHC.Exts            (fromString)
+import qualified GHC.IO.Encoding     as Encoding
 
 import           Options.Applicative
 
-import           System.Environment      (lookupEnv)
-import           System.Exit             (exitFailure)
-import           System.IO               (stderr)
+import           System.Environment  (lookupEnv)
+import           System.Exit         (exitFailure)
+import           System.IO           (stderr)
 
-import qualified Theta.Import            as Theta
-import           Theta.Versions          (packageVersion')
+import qualified Theta.Import        as Theta
+import           Theta.Pretty        (pr, pretty)
+import           Theta.Versions      (packageVersion')
 
-import qualified Apps.Avro               as Avro
-import qualified Apps.Hash               as Hash
-import qualified Apps.Kotlin             as Kotlin
-import qualified Apps.List               as List
-import qualified Apps.Python             as Python
-import qualified Apps.Rust               as Rust
-import           Apps.Subcommand         (Subcommand, runTheta)
+import qualified Apps.Avro           as Avro
+import qualified Apps.Hash           as Hash
+import qualified Apps.Kotlin         as Kotlin
+import qualified Apps.List           as List
+import qualified Apps.Python         as Python
+import qualified Apps.Rust           as Rust
+import           Apps.Subcommand     (Subcommand, runTheta)
 
 main :: IO ()
 main = do
@@ -39,12 +40,12 @@ main = do
 -- * Help
 
 title :: InfoMod a
-title = header [__i|
-  theta (#{packageVersion'}) - define interfaces with algebraic data types
+title = header [pr|
+  theta ({pretty packageVersion'}) - define interfaces with algebraic data types
 |]
 
 description :: InfoMod a
-description = progDesc [__i|
+description = progDesc [pr|
   Theta is a language for formally specifying interfaces using
   algebraic data types.
 
@@ -90,14 +91,14 @@ thetaOptions = ThetaOptions <$> (mconcat <$> loadPath) <*> subcommands
           )
 
 run :: ThetaOptions -> IO ()
-run Version = putStrLn [i|Theta #{packageVersion'}|]
+run Version = putStrLn [pr|Theta {packageVersion'}|]
 run ThetaOptions { loadPath, subcommand } = do
   path <- maybe lookupPath pure loadPath
   runTheta $ subcommand path
   where lookupPath = lookupEnv "THETA_LOAD_PATH" >>= \case
           Just path -> pure $ fromString path
           Nothing   -> do
-            Text.hPutStrLn stderr [__i|
+            Text.hPutStrLn stderr [pr|
               No Theta load path set. You can either:
                 • specify the load path on the command line with the (--path|-p) argument
                 • set the THETA_LOAD_PATH environment variable

--- a/theta/default.nix
+++ b/theta/default.nix
@@ -6,7 +6,7 @@
 
 , overrides ? (new: old: {})
 
-, source-overrides ? {}
+, source-overrides
 
 , build-tools ? [               # extra tools available for nix develop
   # hack to work around stylish-haskell not building with

--- a/theta/src/Theta/Parser.hs
+++ b/theta/src/Theta/Parser.hs
@@ -34,7 +34,7 @@ import qualified Text.Megaparsec.Char.Lexer as L
 import           Theta.Metadata             (Metadata, Version (..))
 import qualified Theta.Metadata             as Metadata
 import qualified Theta.Name                 as Name
-import           Theta.Pretty               (p, pretty)
+import           Theta.Pretty               (pr, pretty)
 import           Theta.Primitive            (definedIn, primitiveKeyword,
                                              primitives)
 import           Theta.Types                (BaseType (..), BaseType' (..),
@@ -101,9 +101,9 @@ versionError :: Text
              -> Version
              -- ^ The version of the current module.
              -> String
-versionError feature minVersion v = [p|
-    Support for #{feature} requires language-version ≥ #{pretty minVersion}
-    Current module being parsed has language-version = #{pretty v}
+versionError feature minVersion v = [pr|
+    Support for {feature} requires language-version ≥ {pretty minVersion}
+    Current module being parsed has language-version = {pretty v}
   |]
 
 -- * Metadata

--- a/theta/src/Theta/Pretty.hs
+++ b/theta/src/Theta/Pretty.hs
@@ -62,6 +62,12 @@ deriving via ShowPretty Word instance Pretty Word
 pr :: QuasiQuoter
 pr = PyF.fmtTrim
 
+-- | Original name for 'pr', but it conflicts with Template Haskell,
+-- so use 'pr' instead.
+p :: QuasiQuoter
+p = pr
+{-# DEPRECATED p "Use pr instead" #-}
+
 -- | The same as 'pretty' but returns a 'String'.
 showPretty :: Pretty a => a -> String
 showPretty = Text.unpack . pretty

--- a/theta/src/Theta/Target/Avro/Types.hs
+++ b/theta/src/Theta/Target/Avro/Types.hs
@@ -49,7 +49,6 @@ import           Data.List.NonEmpty         (NonEmpty (..))
 import qualified Data.List.NonEmpty         as NonEmpty
 import           Data.Set                   (Set)
 import qualified Data.Set                   as Set
-import           Data.String.Interpolate    (__i)
 import qualified Data.Vector                as Vector
 
 import qualified Theta.Error                as Theta
@@ -57,11 +56,12 @@ import           Theta.Metadata             (Version)
 import qualified Theta.Metadata             as Metadata
 import           Theta.Name                 (Name)
 import qualified Theta.Name                 as Name
+import           Theta.Pretty               (pr, pretty)
 import qualified Theta.Primitive            as Theta
 import           Theta.Target.Avro.Error
 import           Theta.Types
+import qualified Theta.Types                as Theta
 import qualified Theta.Versions             as Versions
-import qualified Theta.Types as Theta
 
 -- | Transform a Theta type into a full Avro schema.
 --
@@ -140,10 +140,9 @@ toSchema Definition { definitionType } =
     annotation Nothing    = Just message
     annotation (Just doc) = Just $ message <> "\\n" <> doc
 
-    message = [__i|
-      Generated with Theta #{Versions.packageVersion'}
-      Type hash: #{hash definitionType}
-    |]
+    message = [pr|
+      Generated with Theta {pretty Versions.packageVersion'}
+      Type hash: {show $ hash definitionType}|]
 
     toSchema' t = evalStateT (typeToAvro avroVersion t) Set.empty
 

--- a/theta/src/Theta/Target/Haskell/Conversion.hs
+++ b/theta/src/Theta/Target/Haskell/Conversion.hs
@@ -59,7 +59,7 @@ import           Text.Printf                   (printf)
 
 import qualified Theta.Error                   as Theta
 import           Theta.Name                    (Name)
-import           Theta.Pretty                  (p)
+import           Theta.Pretty                  (pr)
 import qualified Theta.Pretty                  as Theta
 import           Theta.Types                   (prettyType)
 import qualified Theta.Types                   as Theta
@@ -528,12 +528,12 @@ data ConversionError =
 
 instance Theta.Pretty ConversionError where
   pretty (TypeMismatch expected got context) =
-    [p|
+    [pr|
        Type mismatch.
 
-       Expected: ‘#{prettyType expected}’
-       But got:  ‘#{prettyType got}’
-         #{renderedContext}
+       Expected: ‘{prettyType expected}’
+       But got:  ‘{prettyType got}’
+         {renderedContext}
       |]
       where renderedContext :: Text
             renderedContext = case context of
@@ -542,22 +542,22 @@ instance Theta.Pretty ConversionError where
                 "\nin:\n" <> Text.intercalate "\n" (("↳ " <>) . prettyType <$> context)
 
   pretty (BinaryError type_ message) =
-    [p|
-       Error parsing ‘#{prettyType type_}’ from a binary Avro input:
+    [pr|
+       Error parsing ‘{prettyType type_}’ from a binary Avro input:
 
-       #{message}
+       {message}
       |]
 
   pretty (LeftOver type_ remainder) =
-    [p|
-       Error parsing ‘#{prettyType type_}’ from a binary Avro input:
+    [pr|
+       Error parsing ‘{prettyType type_}’ from a binary Avro input:
 
-       #{LBS.length remainder} bytes of the input remains unconsumed.
+       {LBS.length remainder} bytes of the input remains unconsumed.
       |]
 
   pretty (FixedSizeMismatch expected got) =
-    [p|
-      Expected a fixed-size value with #{expected} bytes but got #{got} bytes.
+    [pr|
+      Expected a fixed-size value with {expected} bytes but got {got} bytes.
       |]
 
 -- * Testing

--- a/theta/src/Theta/Target/Python.hs
+++ b/theta/src/Theta/Target/Python.hs
@@ -40,7 +40,7 @@ import qualified Data.Text.Encoding              as Text
 
 import qualified Theta.Error                     as Theta
 import qualified Theta.Name                      as Name
-import           Theta.Pretty                    (p)
+import           Theta.Pretty                    (pr)
 import qualified Theta.Pretty                    as Theta
 import qualified Theta.Types                     as Theta
 
@@ -422,7 +422,7 @@ data PythonError = NonExistentType Name.Name
 instance Theta.Pretty PythonError where
   pretty = \case
     NonExistentType name ->
-      [p| The name ‘#{Theta.pretty name}’ is not defined. |]
+      [pr| The name ‘{Theta.pretty name}’ is not defined. |]
 
 -- | Throw a Python 3 error.
 throw :: MonadError Theta.Error m => PythonError -> m a

--- a/theta/src/Theta/Versions.hs
+++ b/theta/src/Theta/Versions.hs
@@ -79,7 +79,7 @@ avro = Range { name = "avro-version", lower = "1.0.0", upper = "1.2.0" }
 
 -- | Which version of the Theta package this is.
 packageVersion :: Cabal.Version
-packageVersion = Cabal.makeVersion [1, 0, 0, 1]
+packageVersion = Cabal.makeVersion [1, 0, 0, 2]
 
 -- | Which version of the Theta package this is as 'Text'.
 packageVersion' :: Text

--- a/theta/test/Test/Theta/Import.hs
+++ b/theta/test/Test/Theta/Import.hs
@@ -20,7 +20,6 @@ module Test.Theta.Import where
 
 import           Control.Monad.Except          (runExceptT)
 
-import           Data.String.Interpolate       (__i)
 import qualified Data.Text                     as Text
 
 import           System.FilePath               (joinPath, takeExtension, (<.>),
@@ -30,7 +29,7 @@ import           Theta.Error
 import           Theta.Import
 import qualified Theta.Metadata                as Metadata
 import qualified Theta.Name                    as Name
-import           Theta.Pretty                  (pretty)
+import           Theta.Pretty                  (pr, pretty)
 import qualified Theta.Primitive               as Theta
 import           Theta.Types                   (Module (..))
 import qualified Theta.Types                   as Theta
@@ -186,10 +185,10 @@ test_getModuleDefinition = testGroup "getModuleDefinition"
         assertFailure "Did not raise an error as expected."
 
     assertValid Right{}    = pure ()
-    assertValid (Left err) = assertFailure [__i|
+    assertValid (Left err) = assertFailure [pr|
       Expected module to load without errors, but got:
 
-      #{pretty err}
+      {pretty err}
     |]
 
 test_getDefinition :: TestTree
@@ -202,9 +201,9 @@ test_getDefinition = testGroup "getDefinition"
       definition <- runExceptT $ getDefinition loadPath "foo.Bar"
       case Theta.definitionType <$> definition of
         Right t  -> t @?= expected
-        Left err -> assertFailure [__i|
-          Except type #{pretty expected} but got error:
-          #{pretty err}
+        Left err -> assertFailure [pr|
+          Except type {pretty expected} but got error:
+          {pretty err}
         |]
 
   , testCase "missing" $ do
@@ -214,24 +213,24 @@ test_getDefinition = testGroup "getDefinition"
       failed <- runExceptT $ getDefinition loadPath "foo.NotInScope"
       case Theta.definitionType <$> failed of
         Left (MissingName name) -> name @?= "foo.NotInScope"
-        Left err -> assertFailure [__i|
+        Left err -> assertFailure [pr|
           Wrong kind of error. Expected missing name, got:
-          #{pretty err}
+          {pretty err}
         |]
-        Right type_ -> assertFailure [__i|
+        Right type_ -> assertFailure [pr|
           Expected missing name error but got:
-          #{pretty type_}
+          {pretty type_}
         |]
 
       noModule <- runExceptT $ getDefinition loadPath "notInScope.NotInScope"
       case Theta.definitionType <$> noModule of
         Left (MissingModule _ name) -> name @?= "notInScope"
-        Left err -> assertFailure [__i|
+        Left err -> assertFailure [pr|
           Wrong kind of error. Expected missing name, got:
-          #{pretty err}
+          {pretty err}
         |]
-        Right type_ -> assertFailure [__i|
+        Right type_ -> assertFailure [pr|
           Expected missing name error but got:
-          #{pretty type_}
+          {pretty type_}
         |]
   ]

--- a/theta/test/Test/Theta/Target/Avro/Types.hs
+++ b/theta/test/Test/Theta/Target/Avro/Types.hs
@@ -21,7 +21,6 @@ import qualified Data.Avro.Schema.Schema       as Avro
 import           Data.Foldable                 (toList)
 import           Data.Set                      (Set)
 import qualified Data.Set                      as Set
-import           Data.String.Interpolate       (__i)
 import           Data.Tagged                   (Tagged (..))
 import qualified Data.Text                     as Text
 import qualified Data.Vector                   as Vector
@@ -34,6 +33,7 @@ import           Test.Tasty.HUnit
 import qualified Theta.Error                   as Theta
 import qualified Theta.Metadata                as Metadata
 import           Theta.Name                    (Name)
+import           Theta.Pretty                  (pr)
 import qualified Theta.Pretty                  as Theta
 import           Theta.Types
 import qualified Theta.Versions                as Theta
@@ -304,10 +304,9 @@ test_documentation = testGroup "documentation"
       let user = typeToAvro "1.0.0" $ HasTheta.theta @User
       check (Avro.doc <$> user) (Just "User metadata.")
 
-      let username_id_doc = [__i|
+      let username_id_doc = [pr|
         An opaque identifier to distinguish users with identical
-        usernames.
-      |]
+        usernames.|]
       check (Avro.fldDoc . head . Avro.fields <$> user) (Just username_id_doc)
 
   , testCase "variant" $ do
@@ -354,10 +353,9 @@ test_toSchema = testCase "toSchema" $ do
   let expected = Avro.Record "test.OneField" [] docs [foo]
       foo      = Avro.Field "foo" [] Nothing Nothing (Avro.String Nothing) Nothing
       docs     = Just
-        [__i|
-          Generated with Theta #{Theta.packageVersion'}
-          Type hash: 00c870b76a493aaac9709ea3b9968cc5
-            |]
+        [pr|
+          Generated with Theta {Theta.packageVersion'}
+          Type hash: 00c870b76a493aaac9709ea3b9968cc5|]
 
   case toSchema $ getDefinition "test.OneField" of
     Left err  -> fail $ Text.unpack $ Theta.pretty err

--- a/theta/test/Test/Theta/Types.hs
+++ b/theta/test/Test/Theta/Types.hs
@@ -16,7 +16,6 @@ import           Control.Monad                 (forM_)
 import qualified Data.List.NonEmpty            as NonEmpty
 import qualified Data.Map                      as Map
 import qualified Data.Set                      as Set
-import           Data.String.Interpolate       (i)
 import qualified Data.Text                     as Text
 
 import           Text.Printf                   (printf)
@@ -24,7 +23,7 @@ import           Text.Printf                   (printf)
 import           Test.Tasty
 import           Test.Tasty.HUnit
 
-import           Theta.Pretty                  (pretty)
+import           Theta.Pretty                  (pr, pretty)
 import           Theta.Primitive               (primitives)
 import qualified Theta.Primitive               as Theta
 import           Theta.Target.Haskell          (loadModule)
@@ -147,7 +146,7 @@ test_lookupName = testCase "lookupName" $ do
   assertPresent "d.D" theta'd
   where assertPresent name module_ = case Theta.lookupName name module_ of
           Left _ -> assertFailure
-            [i|Could not find #{pretty name} in #{pretty $ Theta.moduleName module_}.|]
+            [pr|Could not find {pretty name} in {pretty $ Theta.moduleName module_}.|]
           Right _  -> pure ()
 
 test_underlyingType :: TestTree

--- a/theta/theta.cabal
+++ b/theta/theta.cabal
@@ -1,6 +1,6 @@
 cabal-version:  2.2
 name:           theta
-version:        1.0.0.1
+version:        1.0.0.2
 synopsis:       Share algebraic data types across different languages with Avro.
 description:    Use algebraic data types to define data formats that work across different languages. Theta lets you use a single set of types to generate Avro schemas as well as types that serialize and deserialize to those schemas in Python, Haskell and Rust.
 license:        Apache-2.0
@@ -35,7 +35,6 @@ common shared
 
                , aeson
                , aeson-pretty >=0.8.9 && <0.9
-               , aeson-qq
                , avro >=0.6 && <0.7
                , binary
                , bytestring
@@ -53,11 +52,11 @@ common shared
                , prettyprinter
                , prettyprinter-ansi-terminal
                , pureMD5
+               , PyF == 0.10.*
                , QuickCheck
                , streamly ==0.8.1.*
                , streamly-bytestring ==0.1.4
                , streamly-process ==0.2.*
-               , string-interpolate >= 0.2.1
                , template-haskell
                , text
                , tagged


### PR DESCRIPTION
`string-interpolate` is still using `haskell-src-exts`, so switching to `PyF` helps me avoid that dependency. (See #67)

This required small changes across a bunch of the codebase, but should not change any behavior.